### PR TITLE
Redeclared types

### DIFF
--- a/tests/test_c_lexer.py
+++ b/tests/test_c_lexer.py
@@ -22,6 +22,12 @@ class TestCLexerNoErrors(unittest.TestCase):
     def error_func(self, msg, line, column):
         self.fail(msg)
 
+    def on_lbrace_func(self):
+        pass
+
+    def on_rbrace_func(self):
+        pass
+
     def type_lookup_func(self, typ):
         if typ.startswith('mytype'):
             return True
@@ -29,7 +35,8 @@ class TestCLexerNoErrors(unittest.TestCase):
             return False
 
     def setUp(self):
-        self.clex = CLexer(self.error_func, self.type_lookup_func)
+        self.clex = CLexer(self.error_func, self.on_lbrace_func,
+                self.on_rbrace_func, self.type_lookup_func)
         self.clex.build(optimize=False)
 
     def assertTokensTypes(self, str, types):
@@ -331,11 +338,18 @@ class TestCLexerErrors(unittest.TestCase):
     def error_func(self, msg, line, column):
         self.error = msg
 
+    def on_lbrace_func(self):
+        pass
+
+    def on_rbrace_func(self):
+        pass
+
     def type_lookup_func(self, typ):
         return False
 
     def setUp(self):
-        self.clex = CLexer(self.error_func, self.type_lookup_func)
+        self.clex = CLexer(self.error_func, self.on_lbrace_func,
+                self.on_rbrace_func, self.type_lookup_func)
         self.clex.build(optimize=False)
         self.error = ""
 


### PR DESCRIPTION
While using pycparser to parse a large, existing codebase, I immediately came upon the typedef-name problem. The changes in this pull request resolve and test for the issues encountered; in particular:
- Reusing typedef names as structure/union member names
- Reusing typedef names as variables names in inner scopes
- Reusing typedef names as parameter names in declarations and definitions
- Duplicated typedef declarations (non-standard, but apparently common and syntactically
  similar to the above)

There is a corner case regarding parameter name scoping that required access to yacc.py's lookahead token (see p_direct_declarator_5 in c_parser.py for details). There are three solutions as I see it:
- Modify yacc.py to expose the lookahead token as an attribute of the parser (...but requiring future PLY updates to be merged, not copied)
- Keep track of the most-recent token via a custom tokenfunc (...but trusting that the parser's lookaheadstack is empty)
- Use the inspect module to grab the value of the parser's lookahead variable (...but direct
  inspection of Python frames and local dictionaries is pretty evil)

For the purpose of this change I decided to use the inspect module, as it is the least error-prone (it can inspect lookaheadstack to ensure it's empty) and the least invasive to the codebase. I can instead make lookahead/lookaheadstack attributes, if you're willing to support the merging of PLY.
