### PR TITLE
Dollar signs in identifiers

### DIFF
--- a/pycparser/c_lexer.py
+++ b/pycparser/c_lexer.py
@@ -169,8 +169,8 @@ class CLexer(object):
     ##
     ##
 
-    # valid C identifiers (K&R2: A.2.3)
-    identifier = r'[a-zA-Z_][0-9a-zA-Z_]*'
+    # valid C identifiers (K&R2: A.2.3), plus '$' (supported by some compilers)
+    identifier = r'[a-zA-Z_$][0-9a-zA-Z_$]*'
 
     hex_prefix = '0[xX]'
     hex_digits = '[0-9a-fA-F]+'

--- a/tests/test_c_lexer.py
+++ b/tests/test_c_lexer.py
@@ -44,6 +44,7 @@ class TestCLexerNoErrors(unittest.TestCase):
         self.assertTokensTypes('++', ['PLUSPLUS'])
         self.assertTokensTypes('case int', ['CASE', 'INT'])
         self.assertTokensTypes('caseint', ['ID'])
+        self.assertTokensTypes('$dollar cent$', ['ID', 'ID'])
         self.assertTokensTypes('i ^= 1;', ['ID', 'XOREQUAL', 'INT_CONST_DEC', 'SEMI'])
 
     def test_id_typeid(self):
@@ -353,7 +354,6 @@ class TestCLexerErrors(unittest.TestCase):
 
     def test_trivial_tokens(self):
         self.assertLexerError('@', ERR_ILLEGAL_CHAR)
-        self.assertLexerError('$', ERR_ILLEGAL_CHAR)
         self.assertLexerError('`', ERR_ILLEGAL_CHAR)
         self.assertLexerError('\\', ERR_ILLEGAL_CHAR)
 


### PR DESCRIPTION
While non-standard, this is supported by many compilers:
http://gcc.gnu.org/onlinedocs/gcc/Dollar-Signs.html
http://llvm.org/releases/1.4/docs/ReleaseNotes.html ("Dollar sign is allowed in identifiers")
http://infocenter.arm.com/help/index.jsp?topic=/com.arm.doc.dui0348c/Ciajabbe.html
