### PR TITLE
Locate test data from __file__

### DIFF
--- a/tests/test_c_parser.py
+++ b/tests/test_c_parser.py
@@ -1518,13 +1518,10 @@ class TestCParser_whole_code(TestCParser_base):
         """ Find a c file by name, taking into account the current dir can be
             in a couple of typical places
         """
-        fullnames = [
-            os.path.join('c_files', name),
-            os.path.join('tests', 'c_files', name)]
-        for fullname in fullnames:
-            if os.path.exists(fullname):
-                return open(fullname, 'rU')
-        assert False, "Unreachable"
+        testdir = os.path.dirname(__file__)
+        name = os.path.join(testdir, 'c_files', name)
+        assert os.path.exists(name)
+        return open(name, 'rU')
 
     def test_whole_file(self):
         # See how pycparser handles a whole, real C file.

--- a/tests/test_general.py
+++ b/tests/test_general.py
@@ -15,31 +15,29 @@ class TestParsing(unittest.TestCase):
         """ Find a c file by name, taking into account the current dir can be
             in a couple of typical places
         """
-        fullnames = [
-            os.path.join('c_files', name),
-            os.path.join('tests', 'c_files', name)]
-        for fullname in fullnames:
-            if os.path.exists(fullname):
-                return fullname
-        assert False, "Unreachable"
+        testdir = os.path.dirname(__file__)
+        name = os.path.join(testdir, 'c_files', name)
+        assert os.path.exists(name)
+        return name
 
     def test_without_cpp(self):
         ast = parse_file(self._find_file('example_c_file.c'))
         self.assertTrue(isinstance(ast, c_ast.FileAST))
 
     def test_with_cpp(self):
-        c_files_path = os.path.join('tests', 'c_files')
-        ast = parse_file(self._find_file('memmgr.c'), use_cpp=True,
+        memmgr_path = self._find_file('memmgr.c')
+        c_files_path = os.path.dirname(memmgr_path)
+        ast = parse_file(memmgr_path, use_cpp=True,
             cpp_path=CPPPATH,
             cpp_args='-I%s' % c_files_path)
         self.assertTrue(isinstance(ast, c_ast.FileAST))
-    
+
+        fake_libc = os.path.join(c_files_path, '..', '..',
+                                 'utils', 'fake_libc_include')
         ast2 = parse_file(self._find_file('year.c'), use_cpp=True,
-            cpp_path=CPPPATH, 
-            cpp_args=[
-                r'-Iutils/fake_libc_include',
-                r'-I../utils/fake_libc_include'])
-    
+            cpp_path=CPPPATH,
+            cpp_args=[r'-I%s' % fake_libc])
+
         self.assertTrue(isinstance(ast2, c_ast.FileAST))
 
     def test_cpp_funkydir(self):


### PR DESCRIPTION
Find c_files and fake_libc_include from `__file__` of the unit test,
rather than expecting the test suite to be run from a particular
directory.
