### PR TITLE
Run build tables post install and when building source or binary distribution

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -96,10 +96,6 @@ favorite Python packaging/distribution tool, for example with::
 
     > pip install pycparser
 
-It's recommended to run ``_build_tables.py`` in the **pycparser** code directory
-after installation to make sure the parsing tables are pre-generated. This can
-make your code run faster.
-
 Known problems
 --------------
 

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,27 @@
 import os, sys
 from distutils.core import setup
+from distutils.command.install import install as _install
+from distutils.command.sdist import sdist as _sdist
+
+
+def _run_build_tables(dir):
+    from subprocess import call
+    call([sys.executable, '_build_tables.py'],
+         cwd=os.path.join(dir, 'pycparser'))
+
+
+class install(_install):
+    def run(self):
+        _install.run(self)
+        self.execute(_run_build_tables, (self.install_lib,),
+                     msg="Build the lexing/parsing tables")
+
+
+class sdist(_sdist):
+    def make_release_tree(self, basedir, files):
+        _sdist.make_release_tree(self, basedir, files)
+        self.execute(_run_build_tables, (basedir,),
+                     msg="Build the lexing/parsing tables")
 
 
 setup(
@@ -24,6 +46,7 @@ setup(
         'Programming Language :: Python :: 3',],
     packages=['pycparser', 'pycparser.ply'],
     package_data={'pycparser': ['*.cfg']},
+    cmdclass={'install': install, 'sdist': sdist},
 )
 
 


### PR DESCRIPTION
Add a post install task to execute `_build_tables.py` in the install destination. This avoid avoids `lextab.py` and `yacctab.py` files being created where pycparser is used when installing from source and forgetting to run `_build_tables.py` manually. As an added bonus, also run `_build_tables.py` automatically when building a source or binary distribution.

Closes #5
