### PR TITLE
Bug in c_generator: children now returns a list of 2-tuples

### DIFF
--- a/pycparser/c_generator.py
+++ b/pycparser/c_generator.py
@@ -34,7 +34,7 @@ class CGenerator(object):
         if node is None:
             return ''
         else:
-            return ''.join(self.visit(c) for c in node.children())
+            return ''.join(self.visit(c) for c_name, c in node.children())
 
     def visit_Constant(self, n):
         return n.value


### PR DESCRIPTION
A minor bug, as generic_visit isn't generally called since most node types have a specific visitor, but could occur if someone tries to generate starting at a PtrDecl, for example.
