### PR TITLE
Fixes Github TOC navigation

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -8,7 +8,6 @@ pycparser v2.10
 .. contents::
     :backlinks: none
 
-.. sectnum::
 
 
 Introduction


### PR DESCRIPTION
With sectnum we can't navigate through the TOC on github. Would this affect pypi?