### PR TITLE
Add Any node

### DIFF
--- a/examples/rewrite_ast.py
+++ b/examples/rewrite_ast.py
@@ -9,7 +9,7 @@
 from __future__ import print_function
 import sys
 
-from pycparser import c_parser
+from pycparser import c_parser, c_ast, c_generator
 
 text = r"""
 void func(void)
@@ -18,14 +18,21 @@ void func(void)
 }
 """
 
+generator = c_generator.CGenerator()
+
 parser = c_parser.CParser()
 ast = parser.parse(text)
 print("Before:")
 ast.show(offset=2)
+print("\n%s" % generator.visit(ast))
 
 assign = ast.ext[0].body.block_items[0]
 assign.lvalue.name = "y"
 assign.rvalue.value = 2
 
+ast.ext.insert(0, c_ast.Any("#define f(a) ((a) * 2)"))
+ast.ext.insert(1, c_ast.Any("/* rewrited function */"))
+
 print("After:")
 ast.show(offset=2)
+print("\n%s" % generator.visit(ast))

--- a/pycparser/_c_ast.cfg
+++ b/pycparser/_c_ast.cfg
@@ -101,6 +101,8 @@ ExprList: [exprs**]
 #
 FileAST: [ext**]
 
+Any: [text]
+
 # for (init; cond; next) stmt
 #
 For: [init*, cond*, next*, stmt*]

--- a/pycparser/c_ast.py
+++ b/pycparser/c_ast.py
@@ -414,6 +414,17 @@ class FileAST(Node):
 
     attr_names = ()
 
+class Any(Node):
+    def __init__(self, text, coord=None):
+        self.text = text
+        self.coord = coord
+
+    def children(self):
+        nodelist = []
+        return tuple(nodelist)
+
+    attr_names = ('text',)
+
 class For(Node):
     def __init__(self, init, cond, next, stmt, coord=None):
         self.init = init

--- a/pycparser/c_generator.py
+++ b/pycparser/c_generator.py
@@ -164,9 +164,14 @@ class CGenerator(object):
         for ext in n.ext:
             if isinstance(ext, c_ast.FuncDef):
                 s += self.visit(ext)
+            elif isinstance(ext, c_ast.Any):
+                s += self.visit(ext) + '\n'
             else:
                 s += self.visit(ext) + ';\n'
         return s
+
+    def visit_Any(self, n):
+        return n.text
 
     def visit_Compound(self, n):
         s = self._make_indent() + '{\n'


### PR DESCRIPTION
To write out any text representation under FileAST node is required
by such program that tries to convert inline function to equivalent macro.

This patch adds Any node which is not relevant to parsing but only to
writing out (via generator).

Signed-off-by: Akira Hayakawa ruby.wktk@gmail.com

---

This patch is related to #42 

I hope you like this patch.

The AST-rewrite example is rewritten. The code after the rewrite is now:

``` c
#define f(a) ((a) * 2)
/* rewrited function */
void func(void)
{
  y = 2;
}
```
