### PR TITLE
fix: compare_asts()

### DIFF
--- a/tests/test_c_generator.py
+++ b/tests/test_c_generator.py
@@ -21,6 +21,7 @@ def compare_asts(ast1, ast2):
             return False
         ast1 = ast1[1]
         ast2 = ast2[1]
+        return compare_asts(ast1, ast2)
     for attr in ast1.attr_names:
         if getattr(ast1, attr) != getattr(ast2, attr):
             return False


### PR DESCRIPTION
Add recursive call in case the asts are both tuple.

Signed-off-by: Akira Hayakawa ruby.wktk@gmail.com
