### PR TITLE
Fix pragma error when '=' occurs.

### DIFF
--- a/pycparser/c_lexer.py
+++ b/pycparser/c_lexer.py
@@ -302,7 +302,7 @@ class CLexer(object):
         r'pragma'
         pass
 
-    t_pppragma_ignore = ' \t<>.-{}();+-*/$%@&^~!?:,0123456789'
+    t_pppragma_ignore = ' \t<>.-{}();=+-*/$%@&^~!?:,0123456789'
 
     @TOKEN(string_literal)
     def t_pppragma_STR(self, t): pass

--- a/tests/test_c_lexer.py
+++ b/tests/test_c_lexer.py
@@ -313,6 +313,7 @@ class TestCLexerNoErrors(unittest.TestCase):
         #pragma {pack: 2, smack: 3}
         #pragma <includeme.h> "nowit.h"
         #pragma "string"
+        #pragma somestring="some_other_string"
         #pragma id 124124 and numbers 0235495
         59
         '''
@@ -325,7 +326,7 @@ class TestCLexerNoErrors(unittest.TestCase):
         self.assertEqual(t1.type, 'INT_CONST_DEC')
         t2 = self.clex.token()
         self.assertEqual(t2.type, 'INT_CONST_DEC')
-        self.assertEqual(t2.lineno, 10)
+        self.assertEqual(t2.lineno, 11)
 
 
 


### PR DESCRIPTION
'=' added to pppragma_ignore.
fixes #33
