### PR TITLE
fix: Comma operator in Assignment

### DIFF
--- a/pycparser/c_generator.py
+++ b/pycparser/c_generator.py
@@ -379,7 +379,7 @@ class CGenerator(object):
         """ Visits 'n' and returns its string representation, parenthesized
             if the condition function applied to the node returns True.
         """
-        s = self.visit(n)
+        s = self._visit_expr(n)
         if condition(n):
             return '(' + s + ')'
         else:

--- a/tests/test_c_generator.py
+++ b/tests/test_c_generator.py
@@ -21,6 +21,7 @@ def compare_asts(ast1, ast2):
             return False
         ast1 = ast1[1]
         ast2 = ast2[1]
+        return compare_asts(ast1, ast2)
     for attr in ast1.attr_names:
         if getattr(ast1, attr) != getattr(ast2, attr):
             return False
@@ -205,6 +206,13 @@ class TestCtoC(unittest.TestCase):
         self._assert_ctoc_correct(r'''
             void f() {
                 (0, 0) ? (0, 0) : (0, 0);
+            }
+        ''')
+
+    def test_comma_op_assignment(self):
+        self._assert_ctoc_correct(r'''
+            void f() {
+                i = (a, b, c);
             }
         ''')
 


### PR DESCRIPTION
Signed-off-by: Akira Hayakawa ruby.wktk@gmail.com

---

If we have comma operator as the rvalue of assignment, ctoc test fails. This patch fixes problem.

Without the recursive call of compare_ast(), the assertion doesn't work.
