### PR TITLE
modify example to use print function, rather than print statement

### DIFF
--- a/examples/explore_ast.py
+++ b/examples/explore_ast.py
@@ -143,7 +143,7 @@ while_cond = while_stmt.cond
 # left and right nodes as children. It also has the op attribute,
 # which is just the string representation of the operator.
 #
-#~ print while_cond.op
+#~ print(while_cond.op)
 #~ while_cond.left.show()
 #~ while_cond.right.show()
 


### PR DESCRIPTION
The explore_ast file imports print function from future.  This causes the print statement in the example to fail (it's commented by default, so not immediately obvious).  Have updated to use the print function.
