### PR TITLE
Update array dimension grammar

### DIFF
--- a/tests/test_c_parser.py
+++ b/tests/test_c_parser.py
@@ -396,6 +396,22 @@ class TestCParser_fundamentals(TestCParser_base):
                                        ['TypeDecl', ['IdentifierType', ['int']]]]]],
                     ['TypeDecl', ['IdentifierType', ['int']]]]])
 
+        self.assertEqual(self.get_decl('int zz(int p[restrict][5]);'),
+            ['Decl', 'zz',
+                ['FuncDecl',
+                    [['Decl', 'p', ['ArrayDecl', '', ['restrict'],
+                        ['ArrayDecl', '5', [],
+                            ['TypeDecl', ['IdentifierType', ['int']]]]]]],
+                    ['TypeDecl', ['IdentifierType', ['int']]]]])
+
+        self.assertEqual(self.get_decl('int zz(int p[const restrict static 10][5]);'),
+            ['Decl', 'zz',
+                ['FuncDecl',
+                    [['Decl', 'p', ['ArrayDecl', '10', ['const', 'restrict', 'static'],
+                        ['ArrayDecl', '5', [],
+                            ['TypeDecl', ['IdentifierType', ['int']]]]]]],
+                    ['TypeDecl', ['IdentifierType', ['int']]]]])
+
     def test_qualifiers_storage_specifiers(self):
         def assert_qs(txt, index, quals, storage):
             d = self.parse(txt).ext[index]


### PR DESCRIPTION
These changes update the pycparser grammar to align with C grammar to now allow parsing of constructs like
int f[restrict][5];
which is an example in the draft standard I consulted, and some other valid constructs as well.
I think these constructs are C99, not C11, as I consulted a draft standard numbered 1256 which didn't seem to mention C11 additions like _Generic.
