### PR TITLE
Allow binary constants (e.g.: 0b01010)

### DIFF
--- a/pycparser/c_lexer.py
+++ b/pycparser/c_lexer.py
@@ -129,7 +129,7 @@ class CLexer(object):
         'TYPEID',
 
         # constants
-        'INT_CONST_DEC', 'INT_CONST_OCT', 'INT_CONST_HEX',
+        'INT_CONST_DEC', 'INT_CONST_OCT', 'INT_CONST_HEX', 'INT_CONST_BIN',
         'FLOAT_CONST', 'HEX_FLOAT_CONST',
         'CHAR_CONST',
         'WCHAR_CONST',
@@ -183,12 +183,15 @@ class CLexer(object):
 
     hex_prefix = '0[xX]'
     hex_digits = '[0-9a-fA-F]+'
+    bin_prefix = '0[bB]'
+    bin_digits = '[01]+'
 
     # integer constants (K&R2: A.2.5.1)
     integer_suffix_opt = r'(([uU]ll)|([uU]LL)|(ll[uU]?)|(LL[uU]?)|([uU][lL])|([lL][uU]?)|[uU])?'
     decimal_constant = '(0'+integer_suffix_opt+')|([1-9][0-9]*'+integer_suffix_opt+')'
     octal_constant = '0[0-7]*'+integer_suffix_opt
     hex_constant = hex_prefix+hex_digits+integer_suffix_opt
+    bin_constant = bin_prefix+bin_digits+integer_suffix_opt
 
     bad_octal_constant = '0[0-7]*[89]'
 
@@ -417,6 +420,10 @@ class CLexer(object):
 
     @TOKEN(hex_constant)
     def t_INT_CONST_HEX(self, t):
+        return t
+
+    @TOKEN(bin_constant)
+    def t_INT_CONST_BIN(self, t):
         return t
 
     @TOKEN(bad_octal_constant)

--- a/pycparser/c_parser.py
+++ b/pycparser/c_parser.py
@@ -1573,6 +1573,7 @@ class CParser(PLYParser):
         """ constant    : INT_CONST_DEC
                         | INT_CONST_OCT
                         | INT_CONST_HEX
+                        | INT_CONST_BIN
         """
         p[0] = c_ast.Constant(
             'int', p[1], self._coord(p.lineno(1)))

--- a/tests/test_c_lexer.py
+++ b/tests/test_c_lexer.py
@@ -75,6 +75,7 @@ class TestCLexerNoErrors(unittest.TestCase):
         self.assertTokensTypes('0123456L', ['INT_CONST_OCT'])
 
         self.assertTokensTypes('0xf7', ['INT_CONST_HEX'])
+        self.assertTokensTypes('0b110', ['INT_CONST_BIN'])
         self.assertTokensTypes('0x01202AAbbf7Ul', ['INT_CONST_HEX'])
 
         # no 0 before x, so ID catches it

--- a/tests/test_c_parser.py
+++ b/tests/test_c_parser.py
@@ -1055,6 +1055,10 @@ class TestCParser_fundamentals(TestCParser_base):
         self.assertEqual(self.get_decl_init(d1_1),
             ['Constant', 'float', '0xEF.56p1'])
 
+        d1_2 = 'int bitmask = 0b1001010;'
+        self.assertEqual(self.get_decl_init(d1_2),
+            ['Constant', 'int', '0b1001010'])
+
         d2 = 'long ar[] = {7, 8, 9};'
         #~ self.parse(d2).show()
         self.assertEqual(self.get_decl(d2),


### PR DESCRIPTION
Here is a small patch to allow binary constants (like the existing octal and hex constants)