### PR TITLE
add weakref to c_ast.Node abstract base class; closes #75 and #76

### DIFF
--- a/pycparser/c_ast.py
+++ b/pycparser/c_ast.py
@@ -20,7 +20,7 @@ import sys
 
 
 class Node(object):
-    __slots__ = ()
+    __slots__ = ('__weakref__',)
     """ Abstract base class for AST nodes.
     """
     def children(self):
@@ -794,4 +794,3 @@ class While(Node):
         return tuple(nodelist)
 
     attr_names = ()
-

--- a/tests/test_c_ast.py
+++ b/tests/test_c_ast.py
@@ -2,12 +2,16 @@ import pprint
 import re
 import sys
 import unittest
+import weakref
 
 sys.path.insert(0, '..')
 import pycparser.c_ast as c_ast
 
 
 class Test_c_ast(unittest.TestCase):
+    def test_Node_weakref(self):
+        weakref.ref(c_ast.Constant(type='int', value='6'))
+
     def test_BinaryOp(self):
         b1 = c_ast.BinaryOp(
             op='+',


### PR DESCRIPTION
This pull request ensures that `c_ast.Node` subclasses can have `weakref`s by adding `__weakref__`.

It should make cffi work with pycparser again.

Included is one minimal "canary" sanity test.  I would be happy to add additional tests if you'd like.

Thanks!