### PR TITLE
Add a functional test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,5 +5,7 @@ python:
   - "3.2"
   - "3.3"
   - "3.4"
-script: python tests/all_tests.py
 
+script:
+  - python tests/all_tests.py
+  - ./tests/functional.sh

--- a/tests/functional.sh
+++ b/tests/functional.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+# quick functional test of one of the most popular stacks relying on
+# pycarser; cryptography -> cffi -> pycparser
+
+if [ "$TRAVIS_PYTHON_VERSION" = "3.2" ]; then
+    echo "Not supported on Python 3.2 due to issues with dependencies"
+    exit 0
+fi
+
+pip install -e "git+https://github.com/pyca/cryptography#egg=cryptography"
+cd ${VIRTUAL_ENV}/src/cryptography
+python setup.py test

--- a/tox.ini
+++ b/tox.ini
@@ -4,3 +4,11 @@ envlist = py27,py33,py34
 [testenv]
 commands =
     python tests/all_tests.py
+
+[testenv:functional]
+whitelist_externals =
+    /bin/bash
+setenv =
+    VIRTUAL_ENV = {envdir}
+commands =
+    /bin/bash tests/functional.sh


### PR DESCRIPTION
Although consumers of pycparser should probably check they don't break
with new versions before relying on them, it would be nice if
pycparser also did a little sanity checking of arguably it's main
consumer; the cryptography->cffi->pycparser dependency chain.

This does a quick install and runs the cryptography tests; enough to
ensure there's no huge breakage.

(travis fails on the 3.2 build as idna isn't compatible with Python
3.2 due to it using u"foo")