### PR TITLE
RFC: Allow empty declarations.

### DIFF
--- a/pycparser/c_parser.py
+++ b/pycparser/c_parser.py
@@ -1168,8 +1168,12 @@ class CParser(PLYParser):
     def p_initializer_2(self, p):
         """ initializer : brace_open initializer_list brace_close
                         | brace_open initializer_list COMMA brace_close
+                        | brace_open brace_close
         """
-        p[0] = p[2]
+        if len(p) == 2:
+            p[0] = c_ast.TypeDecl(None, None, None)
+        else:
+            p[0] = p[2]
 
     def p_initializer_list(self, p):
         """ initializer_list    : designation_opt initializer

--- a/tests/test_c_parser.py
+++ b/tests/test_c_parser.py
@@ -1081,6 +1081,14 @@ class TestCParser_fundamentals(TestCParser_base):
                 ['Constant', 'int', '8'],
                 ['Constant', 'int', '9']])
 
+        d2_1 = 'float ar_empty[3] = {};'
+        self.assertEqual(self.get_decl(d2_1),
+            ['Decl', 'ar_empty',
+                ['ArrayDecl', '3', [],
+                    ['TypeDecl', ['IdentifierType', ['float']]]]])
+        self.assertEqual(self.get_decl_init(d2_1),
+            None )
+
         d3 = 'char p = j;'
         self.assertEqual(self.get_decl(d3),
             ['Decl', 'p', ['TypeDecl', ['IdentifierType', ['char']]]])


### PR DESCRIPTION
I've been needing to parse empty declarations, however I am not sure of the correct way to implement this. The code in this pull request allows it to be parsed, but the output may not be 'correct'.

This is for statements like:
- int abc[3] = {}

Thanks in advance for the review.
