### PR TITLE
Add support for C11 atomics.

### DIFF
--- a/examples/cdecl.py
+++ b/examples/cdecl.py
@@ -84,6 +84,8 @@ def _explain_type(decl):
         if decl.dim: arr += '[%s]' % decl.dim.value
 
         return arr + " of " + _explain_type(decl.type)
+    elif typ == c_ast.Atomic:
+        return '_Atomic ' + _explain_type(decl.type)
 
     elif typ == c_ast.FuncDecl:
         if decl.args:
@@ -100,7 +102,7 @@ if __name__ == "__main__":
     if len(sys.argv) > 1:
         c_decl  = sys.argv[1]
     else:
-        c_decl = "char *(*(**foo[][8])())[];"
+        c_decl = "char *(*(**foo[][8])(_Atomic(int*)))[];"
 
     print("Explaining the declaration: " + c_decl + "\n")
     print(explain_c_declaration(c_decl) + "\n")

--- a/pycparser/_c_ast.cfg
+++ b/pycparser/_c_ast.cfg
@@ -21,6 +21,8 @@ ArrayDecl: [type*, dim*, dim_quals]
 
 ArrayRef: [name*, subscript*]
 
+Atomic: [type]
+
 # op: =, +=, /= etc.
 #
 Assignment: [op, lvalue*, rvalue*]

--- a/pycparser/c_ast.py
+++ b/pycparser/c_ast.py
@@ -158,6 +158,18 @@ class ArrayRef(Node):
 
     attr_names = ()
 
+class Atomic(Node):
+    __slots__ = ('type', 'coord', '__weakref__')
+    def __init__(self, type, coord=None):
+        self.type = type
+        self.coord = coord
+
+    def children(self):
+        nodelist = []
+        return tuple(nodelist)
+
+    attr_names = ('type', )
+
 class Assignment(Node):
     __slots__ = ('op', 'lvalue', 'rvalue', 'coord', '__weakref__')
     def __init__(self, op, lvalue, rvalue, coord=None):

--- a/pycparser/c_generator.py
+++ b/pycparser/c_generator.py
@@ -276,6 +276,9 @@ class CGenerator(object):
 
     def visit_FuncDecl(self, n):
         return self._generate_type(n)
+        
+    def visit_Atomic(self, n):
+        return '_Atomic(%s)' % self._generate_type(n.type)
 
     def _generate_struct_union(self, n, name):
         """ Generates code for structs and unions. name should be either

--- a/pycparser/c_lexer.py
+++ b/pycparser/c_lexer.py
@@ -172,6 +172,10 @@ class CLexer(object):
 
         # pre-processor
         'PPHASH',      # '#'
+        
+        # atomic
+        'ATOMIC_SPECIFIER',
+        'ATOMIC_QUALIFIER',
     )
 
     ##
@@ -474,9 +478,17 @@ class CLexer(object):
 
     @TOKEN(identifier)
     def t_ID(self, t):
-        t.type = self.keyword_map.get(t.value, "ID")
-        if t.type == 'ID' and self.type_lookup_func(t.value):
-            t.type = "TYPEID"
+        # The _Atomic keyword can be either a type specifier or qualifier, but
+        # it is only a specifier when followed by a left parenthesis.
+        if t.value == '_Atomic':
+            if self.lexer.clone().token().type == 'LPAREN':
+                t.type = "ATOMIC_SPECIFIER"
+            else:
+                t.type = "ATOMIC_QUALIFIER"
+        else:
+            t.type = self.keyword_map.get(t.value, "ID")
+            if t.type == 'ID' and self.type_lookup_func(t.value):
+                t.type = "TYPEID"
         return t
 
     def t_error(self, t):

--- a/tests/test_c_lexer.py
+++ b/tests/test_c_lexer.py
@@ -331,7 +331,15 @@ class TestCLexerNoErrors(unittest.TestCase):
         t2 = self.clex.token()
         self.assertEqual(t2.type, 'INT_CONST_DEC')
         self.assertEqual(t2.lineno, 11)
-
+        
+    def test_atomic(self):
+        self.assertTokensTypes(
+            r'_Atomic int a',
+            ['ATOMIC_QUALIFIER', 'INT', 'ID'])
+        
+        self.assertTokensTypes(
+            r'_Atomic(int) a',
+            ['ATOMIC_SPECIFIER', 'LPAREN', 'INT', 'RPAREN', 'ID'])
 
 
 # Keeps all the errors the lexer spits in one place, to allow

--- a/utils/fake_libc_include/stdatomic.h
+++ b/utils/fake_libc_include/stdatomic.h
@@ -1,0 +1,69 @@
+#ifndef _STDATOMIC_H
+#define _STDATOMIC_H
+
+#include "stdint.h"
+#include "uchar.h"
+#include "wchar.h"
+
+typedef enum
+{
+    memory_order_relaxed,
+    memory_order_consume,
+    memory_order_acquire,
+    memory_order_release,
+    memory_order_acq_rel,
+    memory_order_seq_cst
+} memory_order;
+
+typedef int atomic_flag;
+
+typedef _Atomic _Bool atomic_bool;
+typedef _Atomic char atomic_char;
+typedef _Atomic signed char atomic_schar;
+typedef _Atomic unsigned char atomic_uchar;
+typedef _Atomic short atomic_short;
+typedef _Atomic unsigned short atomic_ushort;
+typedef _Atomic int atomic_int;
+typedef _Atomic unsigned int atomic_uint;
+typedef _Atomic long atomic_long;
+typedef _Atomic unsigned long atomic_ulong;
+typedef _Atomic long long atomic_llong;
+typedef _Atomic unsigned long long atomic_ullong;
+typedef _Atomic char16_t atomic_char16_t;
+typedef _Atomic char32_t atomic_char32_t;
+typedef _Atomic wchar_t atomic_wchar_t;
+typedef _Atomic int_least8_t atomic_int_least8_t;
+typedef _Atomic uint_least8_t atomic_uint_least8_t;
+typedef _Atomic int_least16_t atomic_int_least16_t;
+typedef _Atomic uint_least16_t atomic_uint_least16_t;
+typedef _Atomic int_least32_t atomic_int_least32_t;
+typedef _Atomic uint_least32_t atomic_uint_least32_t;
+typedef _Atomic int_least64_t atomic_int_least64_t;
+typedef _Atomic uint_least64_t atomic_uint_least64_t;
+typedef _Atomic int_fast8_t atomic_int_fast8_t;
+typedef _Atomic uint_fast8_t atomic_uint_fast8_t;
+typedef _Atomic int_fast16_t atomic_int_fast16_t;
+typedef _Atomic uint_fast16_t atomic_uint_fast16_t;
+typedef _Atomic int_fast32_t atomic_int_fast32_t;
+typedef _Atomic uint_fast32_t atomic_uint_fast32_t;
+typedef _Atomic int_fast64_t atomic_int_fast64_t;
+typedef _Atomic uint_fast64_t atomic_uint_fast64_t;
+typedef _Atomic intptr_t atomic_intptr_t;
+typedef _Atomic uintptr_t atomic_uintptr_t;
+typedef _Atomic size_t atomic_size_t;
+typedef _Atomic ptrdiff_t atomic_ptrdiff_t;
+typedef _Atomic intmax_t atomic_intmax_t;
+typedef _Atomic uintmax_t atomic_uintmax_t;
+
+#define ATOMIC_BOOL_LOCK_FREE (1)
+#define ATOMIC_CHAR_LOCK_FREE (1)
+#define ATOMIC_CHAR16_T_LOCK_FREE (1)
+#define ATOMIC_CHAR32_T_LOCK_FREE (1)
+#define ATOMIC_WCHAR_T_LOCK_FREE (1)
+#define ATOMIC_SHORT_LOCK_FREE (1)
+#define ATOMIC_INT_LOCK_FREE (1)
+#define ATOMIC_LONG_LOCK_FREE (1)
+#define ATOMIC_LLONG_LOCK_FREE (1)
+#define ATOMIC_POINTER_LOCK_FREE (1)
+
+#endif

--- a/utils/fake_libc_include/uchar.h
+++ b/utils/fake_libc_include/uchar.h
@@ -1,0 +1,9 @@
+#ifndef _UCHAR_H
+#define _UCHAR_H
+
+#include "stdint.h"
+
+typedef uint_least16_t char16_t;
+typedef uint_least32_t char32_t;
+
+#endif


### PR DESCRIPTION
Adds the _Atomic type qualifier & specifier and atomic headers. I'll address a couple of design decisions that I made:

The first is the split between the ATOMIC_QUALIFIER and ATOMIC_SPECIFIER tokens, rather than just using a single _ATOMIC keyword token. According to the C11 spec: *"If  the _Atomic keyword is immediately followed by a left parenthesis, it is interpreted as a type specifier (with a type name), not as a type qualifier"* (6.7.2.4). It seemed easier to let the lexer handle this with a quick look-ahead. I did a cursory test with a single token, but it results in a shift/reduce conflict (I imagine there's a way to write the grammar around this, but that's not my forte). Tests still pass, but I think it's more explicit/robust this way.

In order to meet the condition that *"The type name in an atomic type specifier shall not refer to an array type, a function type, an atomic type, or a qualified type."* (6.7.2.4) the parser needed to become aware of the actual type represented by a typedef, so I modified the way the internal _scope_stack works. Rather than holding True/False it holds the c_ast.Typedef or None in the case of identifier objects. This allows the production for the atomic specifier to inspect the type to make sure it follows the rules.

I added *stdatomic.h* and *uchar.h*, but I kept the macros and typedefs in their respective files, despite convention to put them in the *_fake_x.h* files. I figured, at least in the case of the atomic types, there was potential for naming conflicts with libraries that are still in C99 land, so excluding those from always getting included could be a good thing. For the *ATOMIC_X_LOCK_FREE* macros I chose the value of 1 because *"a value of 1 indicates that the type is sometimes lock-free"* (7.17.5), which I think best reflects pycparser's usage in which a potential target compiler's support is unknown.