### PR TITLE
Fake libc include fixes

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,7 +1,7 @@
 recursive-include examples *.c *.h *.py
 recursive-include tests *.c *.h *.py
 recursive-include pycparser *.py *.cfg
-include utils/fake_libc_include/*.h
+recursive-include utils/fake_libc_include *.h
 include README.*
 include LICENSE
 include CHANGES

--- a/utils/fake_libc_include/_fake_typedefs.h
+++ b/utils/fake_libc_include/_fake_typedefs.h
@@ -95,6 +95,7 @@ typedef int pthread_barrier_t;
 typedef int pthread_barrierattr_t;
 typedef int jmp_buf;
 typedef int rlim_t;
+typedef int sa_family_t;
 typedef int sigjmp_buf;
 typedef int stack_t;
 typedef int siginfo_t;


### PR DESCRIPTION
Update the MANIFEST to include fake_libc_include subdirs, add a missing define