### PR TITLE
Update c_generator to add {} around nested NamedInitializers

### DIFF
--- a/pycparser/c_generator.py
+++ b/pycparser/c_generator.py
@@ -279,7 +279,7 @@ class CGenerator(object):
                 s += '.' + name.name
             elif isinstance(name, c_ast.Constant):
                 s += '[' + name.value + ']'
-        s += ' = ' + self.visit(n.expr)
+        s += ' = ' + self._visit_expr(n.expr)
         return s
 
     def visit_FuncDecl(self, n):

--- a/tests/test_c_generator.py
+++ b/tests/test_c_generator.py
@@ -172,6 +172,19 @@ class TestCtoC(unittest.TestCase):
            int i[1][1] = { { 1 } };
         }''')
 
+    def test_nest_named_initializer(self):
+        self._assert_ctoc_correct(r'''struct test
+            {
+                int i;
+                struct test_i_t
+                {
+                    int k;
+                } test_i;
+                int j;
+            };
+            struct test test_var = {.i = 0, .test_i = {.k = 1}, .j = 2};
+        ''')
+
     def test_expr_list_in_initializer_list(self):
         self._assert_ctoc_correct(r'''
         int main()


### PR DESCRIPTION
I've monkey-patched this change in my project which depends on pycparser: http://github.com/jamie-pate/jstruct . It allows nested NamedInitializer lists by calling `_visit_expr()` instead of `visit()` inside `visit_NamedInitializer`.