### PR TITLE
fixed pathes to c-sources in examples

### DIFF
--- a/examples/func_calls.py
+++ b/examples/func_calls.py
@@ -40,7 +40,7 @@ if __name__ == "__main__":
         filename = sys.argv[1]
         func = sys.argv[2]
     else:
-        filename = 'examples/c_files/hash.c'
+        filename = 'c_files/hash.c'
         func = 'malloc'
 
     show_func_calls(filename, func)

--- a/examples/func_defs.py
+++ b/examples/func_defs.py
@@ -41,6 +41,6 @@ if __name__ == "__main__":
     if len(sys.argv) > 1:
         filename  = sys.argv[1]
     else:
-        filename = 'examples/c_files/memmgr.c'
+        filename = 'c_files/memmgr.c'
 
     show_func_defs(filename)

--- a/examples/using_gcc_E_libc.py
+++ b/examples/using_gcc_E_libc.py
@@ -22,7 +22,7 @@ if __name__ == "__main__":
     if len(sys.argv) > 1:
         filename  = sys.argv[1]
     else:
-        filename = 'examples/c_files/year.c'
+        filename = 'c_files/year.c'
 
     ast = parse_file(filename, use_cpp=True,
             cpp_path='gcc',


### PR DESCRIPTION
There have been some wrong pathes in examples like `filename = 'examples/c_files/year.c'`