### PR TITLE
Add "get_parameter_parser()" to create 'targeted' Parser

### DIFF
--- a/examples/eval.py
+++ b/examples/eval.py
@@ -1,0 +1,32 @@
+#-----------------------------------------------------------------
+# pycparser: ceval.py
+#
+# Interactive definition explorer - loads a source file,
+# then accepts type snippets on input which are parsed
+#
+# Takes source filename as command line argument
+#-----------------------------------------------------------------
+
+import sys
+sys.path.extend(['.', '..'])
+
+from pycparser import parse_file, c_parser
+import readline
+
+if __name__ == "__main__":
+    filename = sys.argv[1]
+
+    parser = c_parser.CParser()
+    ast = parse_file(use_cpp = True, filename = filename, parser = parser)
+    # ast is not used, but the parser retains its list of typenames
+
+    argparser = parser.get_parameter_parser()
+
+    while True:
+        line = raw_input('> ')
+        try:
+            decl = argparser.parse(line)
+            decl.show()
+        except:
+            sys.excepthook(*sys.exc_info())
+

--- a/pycparser/c_parser.py
+++ b/pycparser/c_parser.py
@@ -116,11 +116,14 @@ class CParser(PLYParser):
         for rule in rules_with_opt:
             self._create_opt_rule(rule)
 
-        yacctab = yacctab or 'pycparser-%s.yacctab' % start
         if start != 'translation_unit_or_empty':
             # due to the different start symbol, PLY will emit bogus warnings.
             # if logging is desired, the user can still pass a non-None log
             yacc_errorlog = yacc_errorlog or yacc.NullLogger()
+            # yacctab contents depend on the starting state
+            yacctab = yacctab or 'pycparser-%s.yacctab' % start
+        else:
+            yacctab = yacctab or 'pycparser.yacctab'
 
         self.cparser = yacc.yacc(
             module=self,
@@ -148,7 +151,7 @@ class CParser(PLYParser):
         # Keeps track of the last token given to yacc (the lookahead token)
         self._last_yielded_token = None
 
-    def parse(self, text, filename='', debuglevel=0, reset_identifiers = True):
+    def parse(self, text, filename='', debuglevel=0, reset_identifiers=True):
         """ Parses C code and returns an AST.
 
             text:
@@ -184,7 +187,7 @@ class CParser(PLYParser):
             or "constant_expression" states.
         """
         return CParser(
-                identifiers = self._scope_stack[0],
+                identifiers=self._scope_stack[0],
                 *args, **kwargs)
 
     ######################--   PRIVATE   --######################


### PR DESCRIPTION
rewritten version without special Lexer symbol; does more PLY processing runs instead

---

this returns another instance of CParser that is created with a copy of
the parser's current known symbols, and set to function parameter
context as grammar starting symbol.  It's parse function can be called
with a string describing a single parameter, as shown in eval.py:

$ python eval.py fifo.h

> struct fifo \* const \* x
> Decl: x, [], [], []
>   PtrDecl: []
>     PtrDecl: ['const']
>       TypeDecl: x, []
>         Struct: fifo
> int
> Typename: None, []
>   TypeDecl: None, []
>     IdentifierType: ['int']
