### PR TITLE
Convert readthedocs link for their .org -> .io migration for hosted projects

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -34,7 +34,7 @@ Anything that needs C code to be parsed. The following are some uses for
 * Adding specialized extensions to the C language
 
 One of the most popular uses of **pycparser** is in the `cffi
-<https://cffi.readthedocs.org/en/latest/>`_ library, which uses it to parse the
+<https://cffi.readthedocs.io/en/latest/>`_ library, which uses it to parse the
 declarations of C functions and types in order to auto-generate FFIs.
 
 **pycparser** is unique in the sense that it's written in pure Python - a very


### PR DESCRIPTION
As per their email ‘Changes to project subdomains’:

> Starting today, Read the Docs will start hosting projects from subdomains on the domain readthedocs.io, instead of on readthedocs.org. This change addresses some security concerns around site cookies while hosting user generated data on the same domain as our dashboard.

Test Plan: Manually visited all the links I’ve modified.