### PR TITLE
Fix issue #129: allow reuse of typedef-name as identifier in multi-id…

### DIFF
--- a/pycparser/c_parser.py
+++ b/pycparser/c_parser.py
@@ -994,6 +994,7 @@ class CParser(PLYParser):
 
     def p_direct_declarator_1(self, p):
         """ direct_declarator   : ID
+                                | TYPEID
         """
         p[0] = c_ast.TypeDecl(
             declname=p[1],

--- a/tests/test_c_parser.py
+++ b/tests/test_c_parser.py
@@ -1797,6 +1797,19 @@ class TestCParser_typenames(TestCParser_base):
             '''
         self.assertRaises(ParseError, self.parse, s5)
 
+        # naming a variable after an outer-scope type should work even if
+        # it is not declared on its own line
+        s6 = r'''
+            typedef int TT;
+            void f(){
+                int other, TT;
+            }
+            TT a;
+            '''
+        s6_ast = self.parse(s6)
+        self.assertEqual(expand_decl(s6_ast.ext[1].body.block_items[1]),
+                         ['Decl', 'TT', ['TypeDecl', ['IdentifierType', ['int']]]])
+
     def test_parameter_reuse_typedef_name(self):
         # identifiers can be reused as parameter names; parameter name scope
         # begins and ends with the function body; it's important that TT is


### PR DESCRIPTION
…entifier declaration

Issue is reported here:
https://github.com/eliben/pycparser/issues/129
The fix adds 'TYPEID' to the possible values of direct_declarator.
This results in several shift/reduce conflicts, but the tests still
pass.
There is also a new testcase identifying the issue.

I'm not sure whether the shift/reduce conflicts have to be addressed,
but as i have no clue how to avoid them, and the tests all pass, i'm suggesting my fix :)

Here are the actual conflicts:

> Generating LALR tables
> WARNING: 7 shift/reduce conflicts
> WARNING: 57 reduce/reduce conflicts
> WARNING: reduce/reduce conflict in state 19 resolved using rule (direct_declarator -> TYPEID)
> WARNING: rejected rule (typedef_name -> TYPEID) in state 19
> WARNING: reduce/reduce conflict in state 83 resolved using rule (declarator -> pointer TYPEID)
> WARNING: rejected rule (direct_declarator -> TYPEID) in state 83
