### PR TITLE
Don't create pyc files when building tables

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ except ImportError:
 
 def _run_build_tables(dir):
     from subprocess import call
-    call([sys.executable, '_build_tables.py'],
+    call([sys.executable, '-B', '_build_tables.py'],
          cwd=os.path.join(dir, 'pycparser'))
 
 

--- a/setup.py
+++ b/setup.py
@@ -10,9 +10,9 @@ except ImportError:
 
 
 def _run_build_tables(dir):
-    from subprocess import call
-    call([sys.executable, '-B', '_build_tables.py'],
-         cwd=os.path.join(dir, 'pycparser'))
+    from subprocess import check_call
+    check_call([sys.executable, '-B', '_build_tables.py'],
+               cwd=os.path.join(dir, 'pycparser'))
 
 
 class install(_install):


### PR DESCRIPTION
We don't want to include pyc files in source distributions.
