### PR TITLE
report filename if error is "At end of input"

### DIFF
--- a/pycparser/c_parser.py
+++ b/pycparser/c_parser.py
@@ -1703,7 +1703,7 @@ class CParser(PLYParser):
                 self._coord(lineno=p.lineno,
                             column=self.clex.find_tok_column(p)))
         else:
-            self._parse_error('At end of input', '')
+            self._parse_error('At end of input', self.clex.filename)
 
 
 #------------------------------------------------------------------------------


### PR DESCRIPTION
Very simple fix to print filename in case "At end of input" is reported and no line number is given.

Current behavior:
```python
>>> from pycparser import CParser
>>> p = CParser()
>>> p.parse('(', filename='foo.c')
[...]
pycparser.plyparser.ParseError: : At end of input
```

New behavior:
```python
>>> p.parse('(', filename='foo.c')
[...]
pycparser.plyparser.ParseError: foo.c: At end of input
```