### PR TITLE
parse_text, preprocess_text added

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,7 @@ setup(
         C compilers or analysis tools.
     """,
     license='BSD',
-    version='2.17',
+    version='2.18',
     author='Eli Bendersky',
     maintainer='Eli Bendersky',
     author_email='eliben@gmail.com',


### PR DESCRIPTION
As the name suggests, these are two convenience functions that make unit-testing my code working with the resulting AST easier (at least for me). 

It would also be possible to make the ```parse_file()``` and ```preprocess_file()``` functions invoke ```parse_text()``` and ```preprocess_file()``` respectively. However, this would change the behavior of this library as the CPP would be forced to always read from stdin.