### PR TITLE
Add support for the __int128 type.

### DIFF
--- a/pycparser/c_lexer.py
+++ b/pycparser/c_lexer.py
@@ -106,7 +106,7 @@ class CLexer(object):
         'REGISTER', 'OFFSETOF',
         'RESTRICT', 'RETURN', 'SHORT', 'SIGNED', 'SIZEOF', 'STATIC', 'STRUCT',
         'SWITCH', 'TYPEDEF', 'UNION', 'UNSIGNED', 'VOID',
-        'VOLATILE', 'WHILE',
+        'VOLATILE', 'WHILE', '__INT128',
     )
 
     keyword_map = {}

--- a/pycparser/c_parser.py
+++ b/pycparser/c_parser.py
@@ -737,6 +737,7 @@ class CParser(PLYParser):
                             | _COMPLEX
                             | SIGNED
                             | UNSIGNED
+                            | __INT128
         """
         p[0] = c_ast.IdentifierType([p[1]], coord=self._coord(p.lineno(1)))
 

--- a/tests/test_c_parser.py
+++ b/tests/test_c_parser.py
@@ -285,6 +285,11 @@ class TestCParser_fundamentals(TestCParser_base):
                     ],
                 ['TypeDecl', ['IdentifierType', ['int']]]]])
 
+    def test_int128(self):
+        self.assertEqual(self.get_decl('__int128 a;'),
+            ['Decl', 'a', ['TypeDecl', ['IdentifierType', ['__int128']]]])
+
+
     def test_nested_decls(self): # the fun begins
         self.assertEqual(self.get_decl('char** ar2D;'),
             ['Decl', 'ar2D',


### PR DESCRIPTION
This type is not part of the core C99 or C11 standards, but is mentioned
in both documents under "Common extensions".