### PR TITLE
Add argument to CParser.__init__ for overriding the yacc start symbol.

### DIFF
--- a/pycparser/c_parser.py
+++ b/pycparser/c_parser.py
@@ -25,7 +25,8 @@ class CParser(PLYParser):
             yacc_optimize=True,
             yacctab='pycparser.yacctab',
             yacc_debug=False,
-            taboutputdir=''):
+            taboutputdir='',
+            start='translation_unit_or_empty'):
         """ Create a new CParser.
 
             Some arguments for controlling the debug/optimization
@@ -109,7 +110,7 @@ class CParser(PLYParser):
 
         self.cparser = yacc.yacc(
             module=self,
-            start='translation_unit_or_empty',
+            start=start,
             debug=yacc_debug,
             optimize=yacc_optimize,
             tabmodule=yacctab,

--- a/pycparser/c_parser.py
+++ b/pycparser/c_parser.py
@@ -75,6 +75,10 @@ class CParser(PLYParser):
             taboutputdir:
                 Set this parameter to control the location of generated
                 lextab and yacctab files.
+
+            start:
+                Sets the parser start symbol.  By default, it is
+                'translation_unit_or_empty'.
         """
         self.clex = lexer(
             error_func=self._lex_error_func,

--- a/tests/test_c_parser.py
+++ b/tests/test_c_parser.py
@@ -1898,6 +1898,15 @@ class TestCParser_typenames(TestCParser_base):
         self.assertRaises(ParseError, self.parse, s2)
 
 
+class TestCParser_extra(unittest.TestCase):
+    def test_start_symbol(self):
+        parser = c_parser.CParser(lex_optimize=False, yacc_debug=True,
+                                  yacc_optimize=False, yacctab='yacctab',
+                                  start='expression')
+        ast = parser.parse("1 + 2")
+        assert isinstance(ast, BinaryOp)
+
+
 if __name__ == '__main__':
     #~ suite = unittest.TestLoader().loadTestsFromNames(
         #~ ['test_c_parser.TestCParser_fundamentals.test_typedef'])


### PR DESCRIPTION
This has been very useful for me to be able to parse e.g. expressions directly.