### PR TITLE
Fix parsing TYPEIDs in declarators

### DIFF
--- a/pycparser/c_parser.py
+++ b/pycparser/c_parser.py
@@ -1015,19 +1015,19 @@ class CParser(PLYParser):
         p[0] = p[1]
 
     @parameterized(('id', 'ID'), ('typeid', 'TYPEID'), ('typeid_noparen', 'TYPEID'))
-    def _p_XXX_declarator_1(self, p):
+    def p_XXX_declarator_1(self, p):
         """ XXX_declarator  : direct_XXX_declarator
         """
         p[0] = p[1]
 
     @parameterized(('id', 'ID'), ('typeid', 'TYPEID'), ('typeid_noparen', 'TYPEID'))
-    def _p_XXX_declarator_2(self, p):
+    def p_XXX_declarator_2(self, p):
         """ XXX_declarator  : pointer direct_XXX_declarator
         """
         p[0] = self._type_modify_decl(p[2], p[1])
 
     @parameterized(('id', 'ID'), ('typeid', 'TYPEID'), ('typeid_noparen', 'TYPEID'))
-    def _p_direct_XXX_declarator_1(self, p):
+    def p_direct_XXX_declarator_1(self, p):
         """ direct_XXX_declarator   : YYY
         """
         p[0] = c_ast.TypeDecl(
@@ -1037,13 +1037,13 @@ class CParser(PLYParser):
             coord=self._coord(p.lineno(1)))
 
     @parameterized(('id', 'ID'), ('typeid', 'TYPEID'))
-    def _p_direct_XXX_declarator_2(self, p):
+    def p_direct_XXX_declarator_2(self, p):
         """ direct_XXX_declarator   : LPAREN XXX_declarator RPAREN
         """
         p[0] = p[2]
 
     @parameterized(('id', 'ID'), ('typeid', 'TYPEID'), ('typeid_noparen', 'TYPEID'))
-    def _p_direct_XXX_declarator_3(self, p):
+    def p_direct_XXX_declarator_3(self, p):
         """ direct_XXX_declarator   : direct_XXX_declarator LBRACKET type_qualifier_list_opt assignment_expression_opt RBRACKET
         """
         quals = (p[3] if len(p) > 5 else []) or []
@@ -1058,7 +1058,7 @@ class CParser(PLYParser):
         p[0] = self._type_modify_decl(decl=p[1], modifier=arr)
 
     @parameterized(('id', 'ID'), ('typeid', 'TYPEID'), ('typeid_noparen', 'TYPEID'))
-    def _p_direct_XXX_declarator_4(self, p):
+    def p_direct_XXX_declarator_4(self, p):
         """ direct_XXX_declarator   : direct_XXX_declarator LBRACKET STATIC type_qualifier_list_opt assignment_expression RBRACKET
                                     | direct_XXX_declarator LBRACKET type_qualifier_list STATIC assignment_expression RBRACKET
         """
@@ -1080,7 +1080,7 @@ class CParser(PLYParser):
     # Special for VLAs
     #
     @parameterized(('id', 'ID'), ('typeid', 'TYPEID'), ('typeid_noparen', 'TYPEID'))
-    def _p_direct_XXX_declarator_5(self, p):
+    def p_direct_XXX_declarator_5(self, p):
         """ direct_XXX_declarator   : direct_XXX_declarator LBRACKET type_qualifier_list_opt TIMES RBRACKET
         """
         arr = c_ast.ArrayDecl(
@@ -1092,7 +1092,7 @@ class CParser(PLYParser):
         p[0] = self._type_modify_decl(decl=p[1], modifier=arr)
 
     @parameterized(('id', 'ID'), ('typeid', 'TYPEID'), ('typeid_noparen', 'TYPEID'))
-    def _p_direct_XXX_declarator_6(self, p):
+    def p_direct_XXX_declarator_6(self, p):
         """ direct_XXX_declarator   : direct_XXX_declarator LPAREN parameter_type_list RPAREN
                                     | direct_XXX_declarator LPAREN identifier_list_opt RPAREN
         """

--- a/pycparser/c_parser.py
+++ b/pycparser/c_parser.py
@@ -755,29 +755,11 @@ class CParser(PLYParser):
         """
         p[0] = p[1]
 
-    def p_init_declarator_list_1(self, p):
+    def p_init_declarator_list(self, p):
         """ init_declarator_list    : init_declarator
                                     | init_declarator_list COMMA init_declarator
         """
         p[0] = p[1] + [p[3]] if len(p) == 4 else [p[1]]
-
-    # If the code is declaring a variable that was declared a typedef in an
-    # outer scope, yacc will think the name is part of declaration_specifiers,
-    # not init_declarator, and will then get confused by EQUALS.  Pass None
-    # up in place of declarator, and handle this at a higher level.
-    #
-    def p_init_declarator_list_2(self, p):
-        """ init_declarator_list    : EQUALS initializer
-        """
-        p[0] = [dict(decl=None, init=p[2])]
-
-    # Similarly, if the code contains duplicate typedefs of, for example,
-    # array types, the array portion will appear as an abstract declarator.
-    #
-    def p_init_declarator_list_3(self, p):
-        """ init_declarator_list    : abstract_declarator
-        """
-        p[0] = [dict(decl=p[1], init=None)]
 
     # Returns a {decl=<declarator> : init=<initializer>} dictionary
     # If there's no initializer, uses None

--- a/pycparser/c_parser.py
+++ b/pycparser/c_parser.py
@@ -96,6 +96,7 @@ class CParser(PLYParser):
             'expression',
             'identifier_list',
             'init_declarator_list',
+            'id_init_declarator_list',
             'initializer_list',
             'parameter_type_list',
             'block_item_list',
@@ -629,6 +630,7 @@ class CParser(PLYParser):
     #
     def p_decl_body(self, p):
         """ decl_body : declaration_specifiers init_declarator_list_opt
+                      | declaration_specifiers_no_type id_init_declarator_list_opt
         """
         spec = p[1]
 
@@ -810,6 +812,18 @@ class CParser(PLYParser):
     def p_init_declarator(self, p):
         """ init_declarator : declarator
                             | declarator EQUALS initializer
+        """
+        p[0] = dict(decl=p[1], init=(p[3] if len(p) > 2 else None))
+
+    def p_id_init_declarator_list(self, p):
+        """ id_init_declarator_list    : id_init_declarator
+                                       | id_init_declarator_list COMMA init_declarator
+        """
+        p[0] = p[1] + [p[3]] if len(p) == 4 else [p[1]]
+
+    def p_id_init_declarator(self, p):
+        """ id_init_declarator : id_declarator
+                               | id_declarator EQUALS initializer
         """
         p[0] = dict(decl=p[1], init=(p[3] if len(p) > 2 else None))
 

--- a/pycparser/c_parser.py
+++ b/pycparser/c_parser.py
@@ -98,7 +98,6 @@ class CParser(PLYParser):
             'init_declarator_list',
             'initializer_list',
             'parameter_type_list',
-            'specifier_qualifier_list',
             'block_item_list',
             'type_qualifier_list',
             'struct_declarator_list'
@@ -782,15 +781,28 @@ class CParser(PLYParser):
         """
         p[0] = dict(decl=p[1], init=(p[3] if len(p) > 2 else None))
 
+    # Require at least one type specifier in a specifier-qualifier-list
+    #
     def p_specifier_qualifier_list_1(self, p):
-        """ specifier_qualifier_list    : type_qualifier specifier_qualifier_list_opt
+        """ specifier_qualifier_list    : specifier_qualifier_list type_specifier_no_typeid
         """
-        p[0] = self._add_declaration_specifier(p[2], p[1], 'qual')
+        p[0] = self._add_declaration_specifier(p[1], p[2], 'type', append=True)
 
     def p_specifier_qualifier_list_2(self, p):
-        """ specifier_qualifier_list    : type_specifier specifier_qualifier_list_opt
+        """ specifier_qualifier_list    : specifier_qualifier_list type_qualifier
         """
-        p[0] = self._add_declaration_specifier(p[2], p[1], 'type')
+        p[0] = self._add_declaration_specifier(p[1], p[2], 'qual', append=True)
+
+    def p_specifier_qualifier_list_3(self, p):
+        """ specifier_qualifier_list  : type_specifier
+        """
+        p[0] = self._add_declaration_specifier(None, p[1], 'type')
+
+    def p_specifier_qualifier_list_4(self, p):
+        """ specifier_qualifier_list  : type_qualifier_list type_specifier
+        """
+        spec = dict(qual=p[1], storage=[], type=[], function=[])
+        p[0] = self._add_declaration_specifier(spec, p[2], 'type', append=True)
 
     # TYPEID is allowed here (and in other struct/enum related tag names), because
     # struct/enum tags reside in their own namespace and can be named the same as types

--- a/pycparser/c_parser.py
+++ b/pycparser/c_parser.py
@@ -353,7 +353,7 @@ class CParser(PLYParser):
                 coord=typename[0].coord)
         return decl
 
-    def _add_declaration_specifier(self, declspec, newspec, kind):
+    def _add_declaration_specifier(self, declspec, newspec, kind, append=False):
         """ Declaration specifiers are represented by a dictionary
             with the entries:
             * qual: a list of type qualifiers
@@ -367,7 +367,12 @@ class CParser(PLYParser):
             specifier incorporated.
         """
         spec = declspec or dict(qual=[], storage=[], type=[], function=[])
-        spec[kind].insert(0, newspec)
+
+        if append:
+            spec[kind].append(newspec)
+        else:
+            spec[kind].insert(0, newspec)
+
         return spec
 
     def _build_declarations(self, spec, decls, typedef_namespace=False):

--- a/pycparser/c_parser.py
+++ b/pycparser/c_parser.py
@@ -949,22 +949,23 @@ class CParser(PLYParser):
 
     def p_declarator(self, p):
         """ declarator  : id_declarator
+                        | typeid_declarator
         """
         p[0] = p[1]
 
-    @parameterized(('id', 'ID'))
+    @parameterized(('id', 'ID'), ('typeid', 'TYPEID'))
     def _p_XXX_declarator_1(self, p):
         """ XXX_declarator  : direct_XXX_declarator
         """
         p[0] = p[1]
 
-    @parameterized(('id', 'ID'))
+    @parameterized(('id', 'ID'), ('typeid', 'TYPEID'))
     def _p_XXX_declarator_2(self, p):
         """ XXX_declarator  : pointer direct_XXX_declarator
         """
         p[0] = self._type_modify_decl(p[2], p[1])
 
-    @parameterized(('id', 'ID'))
+    @parameterized(('id', 'ID'), ('typeid', 'TYPEID'))
     def _p_direct_XXX_declarator_1(self, p):
         """ direct_XXX_declarator   : YYY
         """
@@ -974,13 +975,13 @@ class CParser(PLYParser):
             quals=None,
             coord=self._coord(p.lineno(1)))
 
-    @parameterized(('id', 'ID'))
+    @parameterized(('id', 'ID'), ('typeid', 'TYPEID'))
     def _p_direct_XXX_declarator_2(self, p):
         """ direct_XXX_declarator   : LPAREN XXX_declarator RPAREN
         """
         p[0] = p[2]
 
-    @parameterized(('id', 'ID'))
+    @parameterized(('id', 'ID'), ('typeid', 'TYPEID'))
     def _p_direct_XXX_declarator_3(self, p):
         """ direct_XXX_declarator   : direct_XXX_declarator LBRACKET type_qualifier_list_opt assignment_expression_opt RBRACKET
         """
@@ -995,7 +996,7 @@ class CParser(PLYParser):
 
         p[0] = self._type_modify_decl(decl=p[1], modifier=arr)
 
-    @parameterized(('id', 'ID'))
+    @parameterized(('id', 'ID'), ('typeid', 'TYPEID'))
     def _p_direct_XXX_declarator_4(self, p):
         """ direct_XXX_declarator   : direct_XXX_declarator LBRACKET STATIC type_qualifier_list_opt assignment_expression RBRACKET
                                     | direct_XXX_declarator LBRACKET type_qualifier_list STATIC assignment_expression RBRACKET
@@ -1017,7 +1018,7 @@ class CParser(PLYParser):
 
     # Special for VLAs
     #
-    @parameterized(('id', 'ID'))
+    @parameterized(('id', 'ID'), ('typeid', 'TYPEID'))
     def _p_direct_XXX_declarator_5(self, p):
         """ direct_XXX_declarator   : direct_XXX_declarator LBRACKET type_qualifier_list_opt TIMES RBRACKET
         """
@@ -1029,7 +1030,7 @@ class CParser(PLYParser):
 
         p[0] = self._type_modify_decl(decl=p[1], modifier=arr)
 
-    @parameterized(('id', 'ID'))
+    @parameterized(('id', 'ID'), ('typeid', 'TYPEID'))
     def _p_direct_XXX_declarator_6(self, p):
         """ direct_XXX_declarator   : direct_XXX_declarator LPAREN parameter_type_list RPAREN
                                     | direct_XXX_declarator LPAREN identifier_list_opt RPAREN
@@ -1058,7 +1059,6 @@ class CParser(PLYParser):
 
         p[0] = self._type_modify_decl(decl=p[1], modifier=func)
 
-    @parameterized(('id', 'ID'))
     def p_pointer(self, p):
         """ pointer : TIMES type_qualifier_list_opt
                     | TIMES type_qualifier_list_opt pointer

--- a/pycparser/c_parser.py
+++ b/pycparser/c_parser.py
@@ -731,26 +731,27 @@ class CParser(PLYParser):
         """
         p[0] = p[1]
 
-    def p_type_specifier_1(self, p):
-        """ type_specifier  : VOID
-                            | _BOOL
-                            | CHAR
-                            | SHORT
-                            | INT
-                            | LONG
-                            | FLOAT
-                            | DOUBLE
-                            | _COMPLEX
-                            | SIGNED
-                            | UNSIGNED
-                            | __INT128
+    def p_type_specifier_no_typeid(self, p):
+        """ type_specifier_no_typeid  : VOID
+                                      | _BOOL
+                                      | CHAR
+                                      | SHORT
+                                      | INT
+                                      | LONG
+                                      | FLOAT
+                                      | DOUBLE
+                                      | _COMPLEX
+                                      | SIGNED
+                                      | UNSIGNED
+                                      | __INT128
         """
         p[0] = c_ast.IdentifierType([p[1]], coord=self._coord(p.lineno(1)))
 
-    def p_type_specifier_2(self, p):
+    def p_type_specifier(self, p):
         """ type_specifier  : typedef_name
                             | enum_specifier
                             | struct_or_union_specifier
+                            | type_specifier_no_typeid
         """
         p[0] = p[1]
 

--- a/pycparser/c_parser.py
+++ b/pycparser/c_parser.py
@@ -107,6 +107,12 @@ class CParser(PLYParser):
         for rule in rules_with_opt:
             self._create_opt_rule(rule)
 
+        for name in dir(self):
+            if name.startswith('_p_'):
+                method = getattr(self, name)
+                if hasattr(method, '_params'):
+                    self._create_param_rules(method)
+
         self.cparser = yacc.yacc(
             module=self,
             start='translation_unit_or_empty',

--- a/pycparser/c_parser.py
+++ b/pycparser/c_parser.py
@@ -363,6 +363,8 @@ class CParser(PLYParser):
 
             This method is given a declaration specifier, and a
             new specifier of a given kind.
+            If `append` is True, the new specifier is added to the end of
+            the specifiers list, otherwise it's added at the beginning.
             Returns the declaration specifier, with the new
             specifier incorporated.
         """

--- a/pycparser/c_parser.py
+++ b/pycparser/c_parser.py
@@ -12,7 +12,7 @@ from .ply import yacc
 
 from . import c_ast
 from .c_lexer import CLexer
-from .plyparser import PLYParser, Coord, ParseError
+from .plyparser import PLYParser, Coord, ParseError, parameterized
 from .ast_transforms import fix_switch_cases
 
 
@@ -947,18 +947,26 @@ class CParser(PLYParser):
 
         p[0] = enumerator
 
-    def p_declarator_1(self, p):
-        """ declarator  : direct_declarator
+    def p_declarator(self, p):
+        """ declarator  : id_declarator
         """
         p[0] = p[1]
 
-    def p_declarator_2(self, p):
-        """ declarator  : pointer direct_declarator
+    @parameterized(('id', 'ID'))
+    def _p_XXX_declarator_1(self, p):
+        """ XXX_declarator  : direct_XXX_declarator
+        """
+        p[0] = p[1]
+
+    @parameterized(('id', 'ID'))
+    def _p_XXX_declarator_2(self, p):
+        """ XXX_declarator  : pointer direct_XXX_declarator
         """
         p[0] = self._type_modify_decl(p[2], p[1])
 
-    def p_direct_declarator_1(self, p):
-        """ direct_declarator   : ID
+    @parameterized(('id', 'ID'))
+    def _p_direct_XXX_declarator_1(self, p):
+        """ direct_XXX_declarator   : YYY
         """
         p[0] = c_ast.TypeDecl(
             declname=p[1],
@@ -966,13 +974,15 @@ class CParser(PLYParser):
             quals=None,
             coord=self._coord(p.lineno(1)))
 
-    def p_direct_declarator_2(self, p):
-        """ direct_declarator   : LPAREN declarator RPAREN
+    @parameterized(('id', 'ID'))
+    def _p_direct_XXX_declarator_2(self, p):
+        """ direct_XXX_declarator   : LPAREN XXX_declarator RPAREN
         """
         p[0] = p[2]
 
-    def p_direct_declarator_3(self, p):
-        """ direct_declarator   : direct_declarator LBRACKET type_qualifier_list_opt assignment_expression_opt RBRACKET
+    @parameterized(('id', 'ID'))
+    def _p_direct_XXX_declarator_3(self, p):
+        """ direct_XXX_declarator   : direct_XXX_declarator LBRACKET type_qualifier_list_opt assignment_expression_opt RBRACKET
         """
         quals = (p[3] if len(p) > 5 else []) or []
         # Accept dimension qualifiers
@@ -985,9 +995,10 @@ class CParser(PLYParser):
 
         p[0] = self._type_modify_decl(decl=p[1], modifier=arr)
 
-    def p_direct_declarator_4(self, p):
-        """ direct_declarator   : direct_declarator LBRACKET STATIC type_qualifier_list_opt assignment_expression RBRACKET
-                                | direct_declarator LBRACKET type_qualifier_list STATIC assignment_expression RBRACKET
+    @parameterized(('id', 'ID'))
+    def _p_direct_XXX_declarator_4(self, p):
+        """ direct_XXX_declarator   : direct_XXX_declarator LBRACKET STATIC type_qualifier_list_opt assignment_expression RBRACKET
+                                    | direct_XXX_declarator LBRACKET type_qualifier_list STATIC assignment_expression RBRACKET
         """
         # Using slice notation for PLY objects doesn't work in Python 3 for the
         # version of PLY embedded with pycparser; see PLY Google Code issue 30.
@@ -1006,8 +1017,9 @@ class CParser(PLYParser):
 
     # Special for VLAs
     #
-    def p_direct_declarator_5(self, p):
-        """ direct_declarator   : direct_declarator LBRACKET type_qualifier_list_opt TIMES RBRACKET
+    @parameterized(('id', 'ID'))
+    def _p_direct_XXX_declarator_5(self, p):
+        """ direct_XXX_declarator   : direct_XXX_declarator LBRACKET type_qualifier_list_opt TIMES RBRACKET
         """
         arr = c_ast.ArrayDecl(
             type=None,
@@ -1017,9 +1029,10 @@ class CParser(PLYParser):
 
         p[0] = self._type_modify_decl(decl=p[1], modifier=arr)
 
-    def p_direct_declarator_6(self, p):
-        """ direct_declarator   : direct_declarator LPAREN parameter_type_list RPAREN
-                                | direct_declarator LPAREN identifier_list_opt RPAREN
+    @parameterized(('id', 'ID'))
+    def _p_direct_XXX_declarator_6(self, p):
+        """ direct_XXX_declarator   : direct_XXX_declarator LPAREN parameter_type_list RPAREN
+                                    | direct_XXX_declarator LPAREN identifier_list_opt RPAREN
         """
         func = c_ast.FuncDecl(
             args=p[3],
@@ -1045,6 +1058,7 @@ class CParser(PLYParser):
 
         p[0] = self._type_modify_decl(decl=p[1], modifier=func)
 
+    @parameterized(('id', 'ID'))
     def p_pointer(self, p):
         """ pointer : TIMES type_qualifier_list_opt
                     | TIMES type_qualifier_list_opt pointer

--- a/pycparser/c_parser.py
+++ b/pycparser/c_parser.py
@@ -576,7 +576,7 @@ class CParser(PLYParser):
     # a declaration list, for old "K&R style" function definitios.
     #
     def p_function_definition_1(self, p):
-        """ function_definition : declarator declaration_list_opt compound_statement
+        """ function_definition : id_declarator declaration_list_opt compound_statement
         """
         # no declaration specifiers - 'int' becomes the default type
         spec = dict(
@@ -593,7 +593,7 @@ class CParser(PLYParser):
             body=p[3])
 
     def p_function_definition_2(self, p):
-        """ function_definition : declaration_specifiers declarator declaration_list_opt compound_statement
+        """ function_definition : declaration_specifiers id_declarator declaration_list_opt compound_statement
         """
         spec = p[1]
 

--- a/pycparser/c_parser.py
+++ b/pycparser/c_parser.py
@@ -951,21 +951,6 @@ class CParser(PLYParser):
         """
         p[0] = self._type_modify_decl(p[2], p[1])
 
-    # Since it's impossible for a type to be specified after a pointer, assume
-    # it's intended to be the name for this declaration.  _add_identifier will
-    # raise an error if this TYPEID can't be redeclared.
-    #
-    def p_declarator_3(self, p):
-        """ declarator  : pointer TYPEID
-        """
-        decl = c_ast.TypeDecl(
-            declname=p[2],
-            type=None,
-            quals=None,
-            coord=self._coord(p.lineno(2)))
-
-        p[0] = self._type_modify_decl(decl, p[1])
-
     def p_direct_declarator_1(self, p):
         """ direct_declarator   : ID
         """

--- a/pycparser/c_parser.py
+++ b/pycparser/c_parser.py
@@ -12,10 +12,11 @@ from .ply import yacc
 
 from . import c_ast
 from .c_lexer import CLexer
-from .plyparser import PLYParser, Coord, ParseError, parameterized
+from .plyparser import PLYParser, Coord, ParseError, parameterized, template
 from .ast_transforms import fix_switch_cases
 
 
+@template
 class CParser(PLYParser):
     def __init__(
             self,
@@ -106,12 +107,6 @@ class CParser(PLYParser):
 
         for rule in rules_with_opt:
             self._create_opt_rule(rule)
-
-        for name in dir(self):
-            if name.startswith('_p_'):
-                method = getattr(self, name)
-                if hasattr(method, '_params'):
-                    self._create_param_rules(method)
 
         self.cparser = yacc.yacc(
             module=self,

--- a/pycparser/c_parser.py
+++ b/pycparser/c_parser.py
@@ -868,20 +868,6 @@ class CParser(PLYParser):
         p[0] = decls
 
     def p_struct_declaration_2(self, p):
-        """ struct_declaration : specifier_qualifier_list abstract_declarator SEMI
-        """
-        # "Abstract declarator?!", you ask?  Structure members can have the
-        # same names as typedefs.  The trouble is that the member's name gets
-        # grouped into specifier_qualifier_list, leaving any remainder to
-        # appear as an abstract declarator, as in:
-        #   typedef int Foo;
-        #   struct { Foo Foo[3]; };
-        #
-        p[0] = self._build_declarations(
-                spec=p[1],
-                decls=[dict(decl=p[2], init=None)])
-
-    def p_struct_declaration_3(self, p):
         """ struct_declaration : SEMI
         """
         p[0] = None

--- a/pycparser/c_parser.py
+++ b/pycparser/c_parser.py
@@ -1015,20 +1015,20 @@ class CParser(PLYParser):
         p[0] = p[1]
 
     @parameterized(('id', 'ID'), ('typeid', 'TYPEID'), ('typeid_noparen', 'TYPEID'))
-    def p_XXX_declarator_1(self, p):
-        """ XXX_declarator  : direct_XXX_declarator
+    def p_xxx_declarator_1(self, p):
+        """ xxx_declarator  : direct_xxx_declarator
         """
         p[0] = p[1]
 
     @parameterized(('id', 'ID'), ('typeid', 'TYPEID'), ('typeid_noparen', 'TYPEID'))
-    def p_XXX_declarator_2(self, p):
-        """ XXX_declarator  : pointer direct_XXX_declarator
+    def p_xxx_declarator_2(self, p):
+        """ xxx_declarator  : pointer direct_xxx_declarator
         """
         p[0] = self._type_modify_decl(p[2], p[1])
 
     @parameterized(('id', 'ID'), ('typeid', 'TYPEID'), ('typeid_noparen', 'TYPEID'))
-    def p_direct_XXX_declarator_1(self, p):
-        """ direct_XXX_declarator   : YYY
+    def p_direct_xxx_declarator_1(self, p):
+        """ direct_xxx_declarator   : yyy
         """
         p[0] = c_ast.TypeDecl(
             declname=p[1],
@@ -1037,14 +1037,14 @@ class CParser(PLYParser):
             coord=self._coord(p.lineno(1)))
 
     @parameterized(('id', 'ID'), ('typeid', 'TYPEID'))
-    def p_direct_XXX_declarator_2(self, p):
-        """ direct_XXX_declarator   : LPAREN XXX_declarator RPAREN
+    def p_direct_xxx_declarator_2(self, p):
+        """ direct_xxx_declarator   : LPAREN xxx_declarator RPAREN
         """
         p[0] = p[2]
 
     @parameterized(('id', 'ID'), ('typeid', 'TYPEID'), ('typeid_noparen', 'TYPEID'))
-    def p_direct_XXX_declarator_3(self, p):
-        """ direct_XXX_declarator   : direct_XXX_declarator LBRACKET type_qualifier_list_opt assignment_expression_opt RBRACKET
+    def p_direct_xxx_declarator_3(self, p):
+        """ direct_xxx_declarator   : direct_xxx_declarator LBRACKET type_qualifier_list_opt assignment_expression_opt RBRACKET
         """
         quals = (p[3] if len(p) > 5 else []) or []
         # Accept dimension qualifiers
@@ -1058,9 +1058,9 @@ class CParser(PLYParser):
         p[0] = self._type_modify_decl(decl=p[1], modifier=arr)
 
     @parameterized(('id', 'ID'), ('typeid', 'TYPEID'), ('typeid_noparen', 'TYPEID'))
-    def p_direct_XXX_declarator_4(self, p):
-        """ direct_XXX_declarator   : direct_XXX_declarator LBRACKET STATIC type_qualifier_list_opt assignment_expression RBRACKET
-                                    | direct_XXX_declarator LBRACKET type_qualifier_list STATIC assignment_expression RBRACKET
+    def p_direct_xxx_declarator_4(self, p):
+        """ direct_xxx_declarator   : direct_xxx_declarator LBRACKET STATIC type_qualifier_list_opt assignment_expression RBRACKET
+                                    | direct_xxx_declarator LBRACKET type_qualifier_list STATIC assignment_expression RBRACKET
         """
         # Using slice notation for PLY objects doesn't work in Python 3 for the
         # version of PLY embedded with pycparser; see PLY Google Code issue 30.
@@ -1080,8 +1080,8 @@ class CParser(PLYParser):
     # Special for VLAs
     #
     @parameterized(('id', 'ID'), ('typeid', 'TYPEID'), ('typeid_noparen', 'TYPEID'))
-    def p_direct_XXX_declarator_5(self, p):
-        """ direct_XXX_declarator   : direct_XXX_declarator LBRACKET type_qualifier_list_opt TIMES RBRACKET
+    def p_direct_xxx_declarator_5(self, p):
+        """ direct_xxx_declarator   : direct_xxx_declarator LBRACKET type_qualifier_list_opt TIMES RBRACKET
         """
         arr = c_ast.ArrayDecl(
             type=None,
@@ -1092,9 +1092,9 @@ class CParser(PLYParser):
         p[0] = self._type_modify_decl(decl=p[1], modifier=arr)
 
     @parameterized(('id', 'ID'), ('typeid', 'TYPEID'), ('typeid_noparen', 'TYPEID'))
-    def p_direct_XXX_declarator_6(self, p):
-        """ direct_XXX_declarator   : direct_XXX_declarator LPAREN parameter_type_list RPAREN
-                                    | direct_XXX_declarator LPAREN identifier_list_opt RPAREN
+    def p_direct_xxx_declarator_6(self, p):
+        """ direct_xxx_declarator   : direct_xxx_declarator LPAREN parameter_type_list RPAREN
+                                    | direct_xxx_declarator LPAREN identifier_list_opt RPAREN
         """
         func = c_ast.FuncDecl(
             args=p[3],

--- a/pycparser/c_parser.py
+++ b/pycparser/c_parser.py
@@ -91,7 +91,7 @@ class CParser(PLYParser):
             'abstract_declarator',
             'assignment_expression',
             'declaration_list',
-            'declaration_specifiers',
+            'declaration_specifiers_no_type',
             'designation',
             'expression',
             'identifier_list',
@@ -701,25 +701,57 @@ class CParser(PLYParser):
         """
         p[0] = p[1] if len(p) == 2 else p[1] + p[2]
 
-    def p_declaration_specifiers_1(self, p):
-        """ declaration_specifiers  : type_qualifier declaration_specifiers_opt
+    # To know when declaration-specifiers end and declarators begin,
+    # we require declaration-specifiers to have at least one
+    # type-specifier, and disallow typedef-names after we've seen any
+    # type-specifier. These are both required by the spec.
+    #
+    def p_declaration_specifiers_no_type_1(self, p):
+        """ declaration_specifiers_no_type  : type_qualifier declaration_specifiers_no_type_opt
         """
         p[0] = self._add_declaration_specifier(p[2], p[1], 'qual')
 
-    def p_declaration_specifiers_2(self, p):
-        """ declaration_specifiers  : type_specifier declaration_specifiers_opt
-        """
-        p[0] = self._add_declaration_specifier(p[2], p[1], 'type')
-
-    def p_declaration_specifiers_3(self, p):
-        """ declaration_specifiers  : storage_class_specifier declaration_specifiers_opt
+    def p_declaration_specifiers_no_type_2(self, p):
+        """ declaration_specifiers_no_type  : storage_class_specifier declaration_specifiers_no_type_opt
         """
         p[0] = self._add_declaration_specifier(p[2], p[1], 'storage')
 
-    def p_declaration_specifiers_4(self, p):
-        """ declaration_specifiers  : function_specifier declaration_specifiers_opt
+    def p_declaration_specifiers_no_type_3(self, p):
+        """ declaration_specifiers_no_type  : function_specifier declaration_specifiers_no_type_opt
         """
         p[0] = self._add_declaration_specifier(p[2], p[1], 'function')
+
+
+    def p_declaration_specifiers_1(self, p):
+        """ declaration_specifiers  : declaration_specifiers type_qualifier
+        """
+        p[0] = self._add_declaration_specifier(p[1], p[2], 'qual', append=True)
+
+    def p_declaration_specifiers_2(self, p):
+        """ declaration_specifiers  : declaration_specifiers storage_class_specifier
+        """
+        p[0] = self._add_declaration_specifier(p[1], p[2], 'storage', append=True)
+
+    def p_declaration_specifiers_3(self, p):
+        """ declaration_specifiers  : declaration_specifiers function_specifier
+        """
+        p[0] = self._add_declaration_specifier(p[1], p[2], 'function', append=True)
+
+    def p_declaration_specifiers_4(self, p):
+        """ declaration_specifiers  : declaration_specifiers type_specifier_no_typeid
+        """
+        p[0] = self._add_declaration_specifier(p[1], p[2], 'type', append=True)
+
+    def p_declaration_specifiers_5(self, p):
+        """ declaration_specifiers  : type_specifier
+        """
+        p[0] = self._add_declaration_specifier(None, p[1], 'type')
+
+    def p_declaration_specifiers_6(self, p):
+        """ declaration_specifiers  : declaration_specifiers_no_type type_specifier
+        """
+        p[0] = self._add_declaration_specifier(p[1], p[2], 'type', append=True)
+
 
     def p_storage_class_specifier(self, p):
         """ storage_class_specifier : AUTO

--- a/pycparser/plyparser.py
+++ b/pycparser/plyparser.py
@@ -72,6 +72,10 @@ def parameterized(*params):
 
 
 def template(cls):
+    """ Class decorator to generate rules from parameterized rule templates.
+
+    See `parameterized` for more information on parameterized rules.
+    """
     for attr_name in dir(cls):
         if attr_name.startswith('p_'):
             method = getattr(cls, attr_name)
@@ -82,11 +86,20 @@ def template(cls):
 
 
 def _create_param_rules(cls, func):
-    """ Creates ply.yacc rules based on a parameterized rule function """
+    """ Create ply.yacc rules based on a parameterized rule function
+
+    Generates new methods (one per each pair of parameters) based on the template
+    rule function `func`, and attaches them to `cls`. The rule function's
+    parameters must be accessible via its `_params` attribute.
+    """
     for xxx, yyy in func._params:
+        # Use the template method's body for each new method
         def param_rule(self, p):
             func(self, p)
 
+        # Substitute in the params for the grammar rule and function name
         param_rule.__doc__ = func.__doc__.replace('xxx', xxx).replace('yyy', yyy)
         param_rule.__name__ = func.__name__.replace('xxx', xxx)
+
+        # Attach the new method to the class
         setattr(cls, param_rule.__name__, param_rule)

--- a/pycparser/plyparser.py
+++ b/pycparser/plyparser.py
@@ -59,9 +59,9 @@ def parameterized(*params):
     """ Decorator to create parameterized rules.
 
     Parameterized rule methods must be named starting with 'p_' and contain
-    'XXX', and their docstrings may contain 'XXX' and 'YYY'. These will be
-    replaced by the given parameter tuples. For example, ``p_XXX_rule()`` with
-    docstring 'XXX_rule  : YYY' when decorated with
+    'xxx', and their docstrings may contain 'xxx' and 'yyy'. These will be
+    replaced by the given parameter tuples. For example, ``p_xxx_rule()`` with
+    docstring 'xxx_rule  : yyy' when decorated with
     ``@parameterized(('id', 'ID'))`` produces ``p_id_rule()`` with the docstring
     'id_rule  : ID'. Using multiple tuples produces multiple rules.
     """
@@ -87,6 +87,6 @@ def _create_param_rules(cls, func):
         def param_rule(self, p):
             func(self, p)
 
-        param_rule.__doc__ = func.__doc__.replace('XXX', xxx).replace('YYY', yyy)
-        param_rule.__name__ = func.__name__.replace('XXX', xxx)
+        param_rule.__doc__ = func.__doc__.replace('xxx', xxx).replace('yyy', yyy)
+        param_rule.__name__ = func.__name__.replace('xxx', xxx)
         setattr(cls, param_rule.__name__, param_rule)

--- a/pycparser/plyparser.py
+++ b/pycparser/plyparser.py
@@ -58,9 +58,9 @@ class PLYParser(object):
 def parameterized(*params):
     """ Decorator to create parameterized rules.
 
-    Parameterized rule methods must be named starting with '_p_' and contain
+    Parameterized rule methods must be named starting with 'p_' and contain
     'XXX', and their docstrings may contain 'XXX' and 'YYY'. These will be
-    replaced by the given parameter tuples. For example, ``_p_XXX_rule()`` with
+    replaced by the given parameter tuples. For example, ``p_XXX_rule()`` with
     docstring 'XXX_rule  : YYY' when decorated with
     ``@parameterized(('id', 'ID'))`` produces ``p_id_rule()`` with the docstring
     'id_rule  : ID'. Using multiple tuples produces multiple rules.
@@ -73,9 +73,10 @@ def parameterized(*params):
 
 def template(cls):
     for attr_name in dir(cls):
-        if attr_name.startswith('_p_'):
+        if attr_name.startswith('p_'):
             method = getattr(cls, attr_name)
             if hasattr(method, '_params'):
+                delattr(cls, attr_name)  # Remove template method
                 _create_param_rules(cls, method)
     return cls
 
@@ -87,5 +88,5 @@ def _create_param_rules(cls, func):
             func(self, p)
 
         param_rule.__doc__ = func.__doc__.replace('XXX', xxx).replace('YYY', yyy)
-        param_rule.__name__ = func.__name__.replace('XXX', xxx)[1:]
+        param_rule.__name__ = func.__name__.replace('XXX', xxx)
         setattr(cls, param_rule.__name__, param_rule)

--- a/tests/test_c_parser.py
+++ b/tests/test_c_parser.py
@@ -1923,10 +1923,12 @@ class TestCParser_typenames(TestCParser_base):
             ['Decl', 'TT', ['TypeDecl', ['IdentifierType', ['int']]]])
         self.assertEqual(expand_decl(items[2]),
             ['Decl', 'uu', ['TypeDecl', ['IdentifierType', ['int']]]])
-        self.assertEqual(expand_init(items[0].init),
-            ['UnaryOp', 'sizeof', ['Typename', ['TypeDecl', ['IdentifierType', ['TT']]]]])
-        self.assertEqual(expand_init(items[2].init),
-            ['UnaryOp', 'sizeof', ['ID', 'TT']])
+
+        # Don't test this until we have support for it
+        # self.assertEqual(expand_init(items[0].init),
+        #     ['UnaryOp', 'sizeof', ['Typename', ['TypeDecl', ['IdentifierType', ['TT']]]]])
+        # self.assertEqual(expand_init(items[2].init),
+        #     ['UnaryOp', 'sizeof', ['ID', 'TT']])
 
     def test_parameter_reuse_typedef_name(self):
         # identifiers can be reused as parameter names; parameter name scope

--- a/tests/test_c_parser.py
+++ b/tests/test_c_parser.py
@@ -77,6 +77,8 @@ def expand_init(init):
         return ['Constant', init.type, init.value]
     elif typ == ID:
         return ['ID', init.name]
+    elif typ == UnaryOp:
+        return ['UnaryOp', init.op, expand_decl(init.expr)]
 
 
 class TestCParser_base(unittest.TestCase):

--- a/tests/test_c_parser.py
+++ b/tests/test_c_parser.py
@@ -993,6 +993,27 @@ class TestCParser_fundamentals(TestCParser_base):
         self.assertEqual(parsed_struct.type.type.decls[0].bitsize.value, '6')
         self.assertEqual(parsed_struct.type.type.decls[1].bitsize.value, '2')
 
+    def test_multi_type_redefinitions(self):
+        s1 = """
+                typedef int a;
+
+                void main ()
+                {
+                    int a, b;
+                }
+             """
+        s1_ast = self.parse(s1)
+        self.assertEqual(expand_decl(s1_ast.ext[1].body.block_items[0]),
+            ['Decl', 'a',
+                ['TypeDecl',
+                    ['IdentifierType', ['int']]]])
+
+        self.assertEqual(expand_decl(s1_ast.ext[1].body.block_items[1]),
+            ['Decl', 'b',
+                ['TypeDecl',
+                    ['IdentifierType', ['int']]]])
+
+
     def test_tags_namespace(self):
         """ Tests that the tags of structs/unions/enums reside in a separate namespace and
             can be named after existing types.


### PR DESCRIPTION
This fixes the parsing of TYPEIDs in declarators (and related expressions) once and for all, removing existing workarounds for specific cases of the problem. In particular, it solves the problem in the current parser where a TYPEID is used in a list of multiple declarators, for which there is no workaround.

All tests are passing for me, and I added 2 more tests related to parsing declarators correctly.

I've tried to organize the commits as logically and discretely as possible to make it clear what is happening in each step:

1. Remove workaround productions
2. Allow TYPEIDs in declarators
3. Restrict `declaration-specifiers` and `specifier-qualifier-list` to contain at least one type-specifier, and only one if it is a `typedef-name`
4. Force `parameter-declaration`s to interpret a TYPEID as a `typedef-name` in cases of ambiguity

It is likely there is some more leftover "workaround" code that can removed, but I decided it was best to do the PR as-is for now, as that may take some careful thought (and maybe more tests to ensure no change in behavior).
