### PR TITLE
Python 3.6 invalid escape sequence deprecation fixes

### DIFF
--- a/examples/c_json.py
+++ b/examples/c_json.py
@@ -49,7 +49,7 @@ from pycparser import parse_file, c_ast
 from pycparser.plyparser import Coord
 
 
-RE_CHILD_ARRAY = re.compile('(.*)\[(.*)\]')
+RE_CHILD_ARRAY = re.compile(r'(.*)\[(.*)\]')
 RE_INTERNAL_ATTR = re.compile('__.*__')
 
 

--- a/pycparser/c_lexer.py
+++ b/pycparser/c_lexer.py
@@ -52,8 +52,8 @@ class CLexer(object):
         # Allow either "# line" or "# <num>" to support GCC's
         # cpp output
         #
-        self.line_pattern = re.compile('([ \t]*line\W)|([ \t]*\d+)')
-        self.pragma_pattern = re.compile('[ \t]*pragma\W')
+        self.line_pattern = re.compile(r'([ \t]*line\W)|([ \t]*\d+)')
+        self.pragma_pattern = re.compile(r'[ \t]*pragma\W')
 
     def build(self, **kwargs):
         """ Builds the lexer from the specification. Must be

--- a/tests/test_c_lexer.py
+++ b/tests/test_c_lexer.py
@@ -430,12 +430,12 @@ class TestCLexerErrors(unittest.TestCase):
         self.assertLexerError("'b\n", ERR_UNMATCHED_QUOTE)
 
         self.assertLexerError("'jx'", ERR_INVALID_CCONST)
-        self.assertLexerError("'\*'", ERR_INVALID_CCONST)
+        self.assertLexerError(r"'\*'", ERR_INVALID_CCONST)
 
     def test_string_literals(self):
-        self.assertLexerError('"jx\9"', ERR_STRING_ESCAPE)
-        self.assertLexerError('"hekllo\* on ix"', ERR_STRING_ESCAPE)
-        self.assertLexerError('L"hekllo\* on ix"', ERR_STRING_ESCAPE)
+        self.assertLexerError(r'"jx\9"', ERR_STRING_ESCAPE)
+        self.assertLexerError(r'"hekllo\* on ix"', ERR_STRING_ESCAPE)
+        self.assertLexerError(r'L"hekllo\* on ix"', ERR_STRING_ESCAPE)
 
     def test_preprocessor(self):
         self.assertLexerError('#line "ka"', ERR_FILENAME_BEFORE_LINE)

--- a/tests/test_c_parser.py
+++ b/tests/test_c_parser.py
@@ -1718,7 +1718,7 @@ class TestCParser_whole_code(TestCParser_base):
 
         self.assertTrue(isinstance(p.ext[0], Typedef))
         self.assertEqual(p.ext[0].coord.line, 213)
-        self.assertEqual(p.ext[0].coord.file, "D:\eli\cpp_stuff\libc_include/stddef.h")
+        self.assertEqual(p.ext[0].coord.file, r"D:\eli\cpp_stuff\libc_include/stddef.h")
 
         self.assertTrue(isinstance(p.ext[-1], FuncDef))
         self.assertEqual(p.ext[-1].coord.line, 15)


### PR DESCRIPTION
https://docs.python.org/3/whatsnew/3.6.html#deprecated-python-behavior