### PR TITLE
C11 & GCC keywords support

### DIFF
--- a/pycparser/_c_ast.cfg
+++ b/pycparser/_c_ast.cfg
@@ -25,6 +25,8 @@ ArrayRef: [name*, subscript*]
 #
 Assignment: [op, lvalue*, rvalue*]
 
+AtomicType: [type*]
+
 BinaryOp: [op, left*, right*]
 
 Break: []

--- a/pycparser/c_ast.py
+++ b/pycparser/c_ast.py
@@ -174,6 +174,19 @@ class Assignment(Node):
 
     attr_names = ('op', )
 
+class AtomicType(Node):
+    __slots__ = ('type', 'coord', '__weakref__')
+    def __init__(self, type, coord=None):
+        self.type = type
+        self.coord = coord
+
+    def children(self):
+        nodelist = []
+        if self.type is not None: nodelist.append(("type", self.type))
+        return tuple(nodelist)
+
+    attr_names = ()
+
 class BinaryOp(Node):
     __slots__ = ('op', 'left', 'right', 'coord', '__weakref__')
     def __init__(self, op, left, right, coord=None):

--- a/pycparser/c_lexer.py
+++ b/pycparser/c_lexer.py
@@ -121,6 +121,11 @@ class CLexer(object):
         else:
             keyword_map[keyword.lower()] = keyword
 
+    # gcc alternate keywords for system headers
+    for keyword in ('const', 'inline', 'restrict', 'signed'):
+        keyword_map['__%s' % keyword] = keyword.upper()
+        keyword_map['__%s__' % keyword] = keyword.upper()
+
     ##
     ## All the tokens recognized by the lexer
     ##

--- a/pycparser/c_lexer.py
+++ b/pycparser/c_lexer.py
@@ -100,21 +100,24 @@ class CLexer(object):
     ## Reserved keywords
     ##
     keywords = (
-        '_BOOL', '_COMPLEX', 'AUTO', 'BREAK', 'CASE', 'CHAR', 'CONST',
+        '_BOOL', '_COMPLEX', '_IMAGINARY',
+        'AUTO', 'BREAK', 'CASE', 'CHAR', 'CONST',
         'CONTINUE', 'DEFAULT', 'DO', 'DOUBLE', 'ELSE', 'ENUM', 'EXTERN',
         'FLOAT', 'FOR', 'GOTO', 'IF', 'INLINE', 'INT', 'LONG',
         'REGISTER', 'OFFSETOF',
         'RESTRICT', 'RETURN', 'SHORT', 'SIGNED', 'SIZEOF', 'STATIC', 'STRUCT',
         'SWITCH', 'TYPEDEF', 'UNION', 'UNSIGNED', 'VOID',
         'VOLATILE', 'WHILE', '__INT128',
+        # C11
+        '_ALIGNOF', '_ATOMIC', '_THREAD_LOCAL', '_NORETURN',
+        # not supported yet: '_ALIGNAS', '_STATIC_ASSERT', '_GENERIC',
     )
 
     keyword_map = {}
     for keyword in keywords:
-        if keyword == '_BOOL':
-            keyword_map['_Bool'] = keyword
-        elif keyword == '_COMPLEX':
-            keyword_map['_Complex'] = keyword
+        if keyword[0] == '_' and keyword[1] != '_':
+            kwcamel = keyword[:2] + keyword[2:].lower()
+            keyword_map[kwcamel] = keyword
         else:
             keyword_map[keyword.lower()] = keyword
 

--- a/pycparser/c_parser.py
+++ b/pycparser/c_parser.py
@@ -758,11 +758,13 @@ class CParser(PLYParser):
                                     | STATIC
                                     | EXTERN
                                     | TYPEDEF
+                                    | _THREAD_LOCAL
         """
         p[0] = p[1]
 
     def p_function_specifier(self, p):
         """ function_specifier  : INLINE
+                                | _NORETURN
         """
         p[0] = p[1]
 
@@ -776,15 +778,23 @@ class CParser(PLYParser):
                                       | FLOAT
                                       | DOUBLE
                                       | _COMPLEX
+                                      | _IMAGINARY
                                       | SIGNED
                                       | UNSIGNED
                                       | __INT128
         """
         p[0] = c_ast.IdentifierType([p[1]], coord=self._token_coord(p, 1))
 
+    def p_atomic_specifier(self, p):
+        """ atomic_specifier : _ATOMIC LPAREN typedef_name RPAREN
+                             | _ATOMIC LPAREN type_specifier_no_typeid RPAREN
+        """
+        p[0] = c_ast.AtomicType(p[3], coord=self._token_coord(p, 1))
+
     def p_type_specifier(self, p):
         """ type_specifier  : typedef_name
                             | enum_specifier
+                            | atomic_specifier
                             | struct_or_union_specifier
                             | type_specifier_no_typeid
         """
@@ -794,6 +804,7 @@ class CParser(PLYParser):
         """ type_qualifier  : CONST
                             | RESTRICT
                             | VOLATILE
+                            | _ATOMIC
         """
         p[0] = p[1]
 
@@ -1578,6 +1589,7 @@ class CParser(PLYParser):
     def p_unary_expression_3(self, p):
         """ unary_expression    : SIZEOF unary_expression
                                 | SIZEOF LPAREN type_name RPAREN
+                                | _ALIGNOF LPAREN type_name RPAREN
         """
         p[0] = c_ast.UnaryOp(
             p[1],

--- a/pycparser/c_parser.py
+++ b/pycparser/c_parser.py
@@ -766,7 +766,7 @@ class CParser(PLYParser):
         """ function_specifier  : INLINE
                                 | _NORETURN
         """
-        p[0] = p[1]
+        p[0] = p[1].replace('__', '')
 
     def p_type_specifier_no_typeid(self, p):
         """ type_specifier_no_typeid  : VOID
@@ -783,7 +783,8 @@ class CParser(PLYParser):
                                       | UNSIGNED
                                       | __INT128
         """
-        p[0] = c_ast.IdentifierType([p[1]], coord=self._token_coord(p, 1))
+        text = p[1].replace('__', '') if p[1] != '__int128' else p[1]
+        p[0] = c_ast.IdentifierType([text], coord=self._token_coord(p, 1))
 
     def p_atomic_specifier(self, p):
         """ atomic_specifier : _ATOMIC LPAREN typedef_name RPAREN
@@ -806,7 +807,7 @@ class CParser(PLYParser):
                             | VOLATILE
                             | _ATOMIC
         """
-        p[0] = p[1]
+        p[0] = p[1].replace('__', '')
 
     def p_init_declarator_list(self, p):
         """ init_declarator_list    : init_declarator

--- a/tests/test_c_parser.py
+++ b/tests/test_c_parser.py
@@ -25,6 +25,8 @@ def expand_decl(decl):
 
     if typ == TypeDecl:
         return ['TypeDecl', expand_decl(decl.type)]
+    elif typ == AtomicType:
+        return ['AtomicType', expand_decl(decl.type)]
     elif typ == IdentifierType:
         return ['IdentifierType', decl.names]
     elif typ == ID:
@@ -244,6 +246,12 @@ class TestCParser_fundamentals(TestCParser_base):
         self.assertEqual(self.get_decl('float _Complex fcc;'),
             ['Decl', 'fcc', ['TypeDecl', ['IdentifierType', ['float', '_Complex']]]])
 
+        self.assertEqual(self.get_decl('_Atomic int fcc;'),
+            ['Decl', ['_Atomic'], 'fcc', ['TypeDecl', ['IdentifierType', ['int']]]])
+
+        self.assertEqual(self.get_decl('_Atomic(int) fcc;'),
+            ['Decl', 'fcc', ['TypeDecl', ['AtomicType', ['IdentifierType', ['int']]]]])
+
         self.assertEqual(self.get_decl('char* string;'),
             ['Decl', 'string',
                 ['PtrDecl', ['TypeDecl', ['IdentifierType', ['char']]]]])
@@ -442,6 +450,7 @@ class TestCParser_fundamentals(TestCParser_base):
 
         assert_qs("extern int p;", 0, [], ['extern'])
         assert_qs("const long p = 6;", 0, ['const'], [])
+        assert_qs("_Thread_local int p;", 0, [], ['_Thread_local'])
 
         d1 = "static const int p, q, r;"
         for i in range(3):
@@ -1326,6 +1335,10 @@ class TestCParser_fundamentals(TestCParser_base):
     def test_inline_specifier(self):
         ps2 = self.parse('static inline void inlinefoo(void);')
         self.assertEqual(ps2.ext[0].funcspec, ['inline'])
+
+    def test_noreturn_specifier(self):
+        ps2 = self.parse('extern _Noreturn void noretfoo(void);')
+        self.assertEqual(ps2.ext[0].funcspec, ['_Noreturn'])
 
     # variable length array
     def test_vla(self):


### PR DESCRIPTION
add support for basic C11 + GCC alternate keywords ("for use in header files")

With this, the only bits still neccessary to strip from standard glibc headers shrinks down to:
```
__attribute__(x)
__extension__
__asm__(x)
__builtin_va_list
```