### PR TITLE
Don't fail if docstrings are disabled

### DIFF
--- a/pycparser/plyparser.py
+++ b/pycparser/plyparser.py
@@ -109,7 +109,10 @@ def _create_param_rules(cls, func):
             func(self, p)
 
         # Substitute in the params for the grammar rule and function name
-        param_rule.__doc__ = func.__doc__.replace('xxx', xxx).replace('yyy', yyy)
+        try:
+            param_rule.__doc__ = func.__doc__.replace('xxx', xxx).replace('yyy', yyy)
+        except AttributeError:
+            pass  # Docstring may not exist
         param_rule.__name__ = func.__name__.replace('xxx', xxx)
 
         # Attach the new method to the class


### PR DESCRIPTION
The attribute `__doc__` will return `None` if running CPython in `-OO` mode [as it discards docstrings](https://docs.python.org/3/using/cmdline.html#cmdoption-OO).

FYI, this broke builds for me because `cryptography` uses `cffi` which uses `pycparser` at install time, and always pulls the latest version regardless of any dependency pinning in `requirements.txt`. It would be nice to prioritize this getting in a release ASAP to fix this issue.