### PR TITLE
Improve NodeVisitor performance, add iterator on Node children (Issue #219).

### DIFF
--- a/pycparser/_ast_gen.py
+++ b/pycparser/_ast_gen.py
@@ -84,6 +84,7 @@ class NodeCfg(object):
     def generate_source(self):
         src = self._gen_init()
         src += '\n' + self._gen_children()
+        src += '\n' + self._gen_iter()
         src += '\n' + self._gen_attr_names()
         return src
 
@@ -128,6 +129,35 @@ class NodeCfg(object):
             src += '        return tuple(nodelist)\n'
         else:
             src += '        return ()\n'
+
+        return src
+
+    def _gen_iter(self):
+        src = '    def __iter__(self):\n'
+
+        if self.all_entries:
+            for child in self.child:
+                src += (
+                    '        if self.%(child)s is not None:\n' +
+                    '            yield self.%(child)s\n') % (dict(child=child))
+
+            for seq_child in self.seq_child:
+                src += (
+                    '        for child in (self.%(child)s or []):\n'
+                    '            yield child\n') % (dict(child=seq_child))
+                    
+            if not (self.child or self.seq_child):
+                # Empty generator
+                src += (
+                    '        return\n' +
+                    '        yield\n'
+                    )
+        else:
+            # Empty generator
+            src += (
+                '        return\n' +
+                '        yield\n'
+                )
 
         return src
 
@@ -253,21 +283,35 @@ class NodeVisitor(object):
         *   Modeled after Python's own AST visiting facilities
             (the ast module of Python 3.0)
     """
+    
+    _method_cache = None
+    
     def visit(self, node):
         """ Visit a node.
         """
-        method = 'visit_' + node.__class__.__name__
-        visitor = getattr(self, method, self.generic_visit)
+        
+        method_cache = self._method_cache
+        if method_cache is None:
+            method_cache = {}
+            self._method_cache = method_cache
+            
+        visitor = method_cache.get(node.__class__.__name__, None)
+        if visitor is None:
+            method = 'visit_' + node.__class__.__name__
+            visitor = getattr(self, method, self.generic_visit)
+            
+            method_cache[node.__class__.__name__] = visitor
+            
         return visitor(node)
 
     def generic_visit(self, node):
         """ Called if no explicit visitor function exists for a
             node. Implements preorder visiting of the node.
         """
-        for c_name, c in node.children():
+        for c in node:
             self.visit(c)
-
-
+            
+            
 '''
 
 

--- a/pycparser/_ast_gen.py
+++ b/pycparser/_ast_gen.py
@@ -290,16 +290,14 @@ class NodeVisitor(object):
         """ Visit a node.
         """
 
-        method_cache = self._method_cache
-        if method_cache is None:
-            method_cache = {}
-            self._method_cache = method_cache
+        if self._method_cache is None:
+            self._method_cache = {}
 
-        visitor = method_cache.get(node.__class__.__name__, None)
+        visitor = self._method_cache.get(node.__class__.__name__, None)
         if visitor is None:
             method = 'visit_' + node.__class__.__name__
             visitor = getattr(self, method, self.generic_visit)
-            method_cache[node.__class__.__name__] = visitor
+            self._method_cache[node.__class__.__name__] = visitor
 
         return visitor(node)
 

--- a/pycparser/_ast_gen.py
+++ b/pycparser/_ast_gen.py
@@ -145,7 +145,7 @@ class NodeCfg(object):
                 src += (
                     '        for child in (self.%(child)s or []):\n'
                     '            yield child\n') % (dict(child=seq_child))
-                    
+
             if not (self.child or self.seq_child):
                 # Empty generator
                 src += (
@@ -283,25 +283,24 @@ class NodeVisitor(object):
         *   Modeled after Python's own AST visiting facilities
             (the ast module of Python 3.0)
     """
-    
+
     _method_cache = None
-    
+
     def visit(self, node):
         """ Visit a node.
         """
-        
+
         method_cache = self._method_cache
         if method_cache is None:
             method_cache = {}
             self._method_cache = method_cache
-            
+
         visitor = method_cache.get(node.__class__.__name__, None)
         if visitor is None:
             method = 'visit_' + node.__class__.__name__
             visitor = getattr(self, method, self.generic_visit)
-            
             method_cache[node.__class__.__name__] = visitor
-            
+
         return visitor(node)
 
     def generic_visit(self, node):
@@ -310,8 +309,7 @@ class NodeVisitor(object):
         """
         for c in node:
             self.visit(c)
-            
-            
+
 '''
 
 

--- a/pycparser/c_ast.py
+++ b/pycparser/c_ast.py
@@ -119,16 +119,14 @@ class NodeVisitor(object):
         """ Visit a node.
         """
 
-        method_cache = self._method_cache
-        if method_cache is None:
-            method_cache = {}
-            self._method_cache = method_cache
+        if self._method_cache is None:
+            self._method_cache = {}
 
-        visitor = method_cache.get(node.__class__.__name__, None)
+        visitor = self._method_cache.get(node.__class__.__name__, None)
         if visitor is None:
             method = 'visit_' + node.__class__.__name__
             visitor = getattr(self, method, self.generic_visit)
-            method_cache[node.__class__.__name__] = visitor
+            self._method_cache[node.__class__.__name__] = visitor
 
         return visitor(node)
 

--- a/pycparser/c_ast.py
+++ b/pycparser/c_ast.py
@@ -112,21 +112,35 @@ class NodeVisitor(object):
         *   Modeled after Python's own AST visiting facilities
             (the ast module of Python 3.0)
     """
+    
+    _method_cache = None
+    
     def visit(self, node):
         """ Visit a node.
         """
-        method = 'visit_' + node.__class__.__name__
-        visitor = getattr(self, method, self.generic_visit)
+        
+        method_cache = self._method_cache
+        if method_cache is None:
+            method_cache = {}
+            self._method_cache = method_cache
+            
+        visitor = method_cache.get(node.__class__.__name__, None)
+        if visitor is None:
+            method = 'visit_' + node.__class__.__name__
+            visitor = getattr(self, method, self.generic_visit)
+            
+            method_cache[node.__class__.__name__] = visitor
+            
         return visitor(node)
 
     def generic_visit(self, node):
         """ Called if no explicit visitor function exists for a
             node. Implements preorder visiting of the node.
         """
-        for c_name, c in node.children():
+        for c in node:
             self.visit(c)
-
-
+            
+            
 class ArrayDecl(Node):
     __slots__ = ('type', 'dim', 'dim_quals', 'coord', '__weakref__')
     def __init__(self, type, dim, dim_quals, coord=None):
@@ -140,6 +154,12 @@ class ArrayDecl(Node):
         if self.type is not None: nodelist.append(("type", self.type))
         if self.dim is not None: nodelist.append(("dim", self.dim))
         return tuple(nodelist)
+
+    def __iter__(self):
+        if self.type is not None:
+            yield self.type
+        if self.dim is not None:
+            yield self.dim
 
     attr_names = ('dim_quals', )
 
@@ -155,6 +175,12 @@ class ArrayRef(Node):
         if self.name is not None: nodelist.append(("name", self.name))
         if self.subscript is not None: nodelist.append(("subscript", self.subscript))
         return tuple(nodelist)
+
+    def __iter__(self):
+        if self.name is not None:
+            yield self.name
+        if self.subscript is not None:
+            yield self.subscript
 
     attr_names = ()
 
@@ -172,6 +198,12 @@ class Assignment(Node):
         if self.rvalue is not None: nodelist.append(("rvalue", self.rvalue))
         return tuple(nodelist)
 
+    def __iter__(self):
+        if self.lvalue is not None:
+            yield self.lvalue
+        if self.rvalue is not None:
+            yield self.rvalue
+
     attr_names = ('op', )
 
 class BinaryOp(Node):
@@ -188,6 +220,12 @@ class BinaryOp(Node):
         if self.right is not None: nodelist.append(("right", self.right))
         return tuple(nodelist)
 
+    def __iter__(self):
+        if self.left is not None:
+            yield self.left
+        if self.right is not None:
+            yield self.right
+
     attr_names = ('op', )
 
 class Break(Node):
@@ -197,6 +235,10 @@ class Break(Node):
 
     def children(self):
         return ()
+
+    def __iter__(self):
+        return
+        yield
 
     attr_names = ()
 
@@ -214,6 +256,12 @@ class Case(Node):
             nodelist.append(("stmts[%d]" % i, child))
         return tuple(nodelist)
 
+    def __iter__(self):
+        if self.expr is not None:
+            yield self.expr
+        for child in (self.stmts or []):
+            yield child
+
     attr_names = ()
 
 class Cast(Node):
@@ -229,6 +277,12 @@ class Cast(Node):
         if self.expr is not None: nodelist.append(("expr", self.expr))
         return tuple(nodelist)
 
+    def __iter__(self):
+        if self.to_type is not None:
+            yield self.to_type
+        if self.expr is not None:
+            yield self.expr
+
     attr_names = ()
 
 class Compound(Node):
@@ -242,6 +296,10 @@ class Compound(Node):
         for i, child in enumerate(self.block_items or []):
             nodelist.append(("block_items[%d]" % i, child))
         return tuple(nodelist)
+
+    def __iter__(self):
+        for child in (self.block_items or []):
+            yield child
 
     attr_names = ()
 
@@ -258,6 +316,12 @@ class CompoundLiteral(Node):
         if self.init is not None: nodelist.append(("init", self.init))
         return tuple(nodelist)
 
+    def __iter__(self):
+        if self.type is not None:
+            yield self.type
+        if self.init is not None:
+            yield self.init
+
     attr_names = ()
 
 class Constant(Node):
@@ -271,6 +335,10 @@ class Constant(Node):
         nodelist = []
         return tuple(nodelist)
 
+    def __iter__(self):
+        return
+        yield
+
     attr_names = ('type', 'value', )
 
 class Continue(Node):
@@ -280,6 +348,10 @@ class Continue(Node):
 
     def children(self):
         return ()
+
+    def __iter__(self):
+        return
+        yield
 
     attr_names = ()
 
@@ -302,6 +374,14 @@ class Decl(Node):
         if self.bitsize is not None: nodelist.append(("bitsize", self.bitsize))
         return tuple(nodelist)
 
+    def __iter__(self):
+        if self.type is not None:
+            yield self.type
+        if self.init is not None:
+            yield self.init
+        if self.bitsize is not None:
+            yield self.bitsize
+
     attr_names = ('name', 'quals', 'storage', 'funcspec', )
 
 class DeclList(Node):
@@ -316,6 +396,10 @@ class DeclList(Node):
             nodelist.append(("decls[%d]" % i, child))
         return tuple(nodelist)
 
+    def __iter__(self):
+        for child in (self.decls or []):
+            yield child
+
     attr_names = ()
 
 class Default(Node):
@@ -329,6 +413,10 @@ class Default(Node):
         for i, child in enumerate(self.stmts or []):
             nodelist.append(("stmts[%d]" % i, child))
         return tuple(nodelist)
+
+    def __iter__(self):
+        for child in (self.stmts or []):
+            yield child
 
     attr_names = ()
 
@@ -345,6 +433,12 @@ class DoWhile(Node):
         if self.stmt is not None: nodelist.append(("stmt", self.stmt))
         return tuple(nodelist)
 
+    def __iter__(self):
+        if self.cond is not None:
+            yield self.cond
+        if self.stmt is not None:
+            yield self.stmt
+
     attr_names = ()
 
 class EllipsisParam(Node):
@@ -355,6 +449,10 @@ class EllipsisParam(Node):
     def children(self):
         return ()
 
+    def __iter__(self):
+        return
+        yield
+
     attr_names = ()
 
 class EmptyStatement(Node):
@@ -364,6 +462,10 @@ class EmptyStatement(Node):
 
     def children(self):
         return ()
+
+    def __iter__(self):
+        return
+        yield
 
     attr_names = ()
 
@@ -379,6 +481,10 @@ class Enum(Node):
         if self.values is not None: nodelist.append(("values", self.values))
         return tuple(nodelist)
 
+    def __iter__(self):
+        if self.values is not None:
+            yield self.values
+
     attr_names = ('name', )
 
 class Enumerator(Node):
@@ -392,6 +498,10 @@ class Enumerator(Node):
         nodelist = []
         if self.value is not None: nodelist.append(("value", self.value))
         return tuple(nodelist)
+
+    def __iter__(self):
+        if self.value is not None:
+            yield self.value
 
     attr_names = ('name', )
 
@@ -407,6 +517,10 @@ class EnumeratorList(Node):
             nodelist.append(("enumerators[%d]" % i, child))
         return tuple(nodelist)
 
+    def __iter__(self):
+        for child in (self.enumerators or []):
+            yield child
+
     attr_names = ()
 
 class ExprList(Node):
@@ -421,6 +535,10 @@ class ExprList(Node):
             nodelist.append(("exprs[%d]" % i, child))
         return tuple(nodelist)
 
+    def __iter__(self):
+        for child in (self.exprs or []):
+            yield child
+
     attr_names = ()
 
 class FileAST(Node):
@@ -434,6 +552,10 @@ class FileAST(Node):
         for i, child in enumerate(self.ext or []):
             nodelist.append(("ext[%d]" % i, child))
         return tuple(nodelist)
+
+    def __iter__(self):
+        for child in (self.ext or []):
+            yield child
 
     attr_names = ()
 
@@ -454,6 +576,16 @@ class For(Node):
         if self.stmt is not None: nodelist.append(("stmt", self.stmt))
         return tuple(nodelist)
 
+    def __iter__(self):
+        if self.init is not None:
+            yield self.init
+        if self.cond is not None:
+            yield self.cond
+        if self.next is not None:
+            yield self.next
+        if self.stmt is not None:
+            yield self.stmt
+
     attr_names = ()
 
 class FuncCall(Node):
@@ -469,6 +601,12 @@ class FuncCall(Node):
         if self.args is not None: nodelist.append(("args", self.args))
         return tuple(nodelist)
 
+    def __iter__(self):
+        if self.name is not None:
+            yield self.name
+        if self.args is not None:
+            yield self.args
+
     attr_names = ()
 
 class FuncDecl(Node):
@@ -483,6 +621,12 @@ class FuncDecl(Node):
         if self.args is not None: nodelist.append(("args", self.args))
         if self.type is not None: nodelist.append(("type", self.type))
         return tuple(nodelist)
+
+    def __iter__(self):
+        if self.args is not None:
+            yield self.args
+        if self.type is not None:
+            yield self.type
 
     attr_names = ()
 
@@ -502,6 +646,14 @@ class FuncDef(Node):
             nodelist.append(("param_decls[%d]" % i, child))
         return tuple(nodelist)
 
+    def __iter__(self):
+        if self.decl is not None:
+            yield self.decl
+        if self.body is not None:
+            yield self.body
+        for child in (self.param_decls or []):
+            yield child
+
     attr_names = ()
 
 class Goto(Node):
@@ -513,6 +665,10 @@ class Goto(Node):
     def children(self):
         nodelist = []
         return tuple(nodelist)
+
+    def __iter__(self):
+        return
+        yield
 
     attr_names = ('name', )
 
@@ -526,6 +682,10 @@ class ID(Node):
         nodelist = []
         return tuple(nodelist)
 
+    def __iter__(self):
+        return
+        yield
+
     attr_names = ('name', )
 
 class IdentifierType(Node):
@@ -537,6 +697,10 @@ class IdentifierType(Node):
     def children(self):
         nodelist = []
         return tuple(nodelist)
+
+    def __iter__(self):
+        return
+        yield
 
     attr_names = ('names', )
 
@@ -555,6 +719,14 @@ class If(Node):
         if self.iffalse is not None: nodelist.append(("iffalse", self.iffalse))
         return tuple(nodelist)
 
+    def __iter__(self):
+        if self.cond is not None:
+            yield self.cond
+        if self.iftrue is not None:
+            yield self.iftrue
+        if self.iffalse is not None:
+            yield self.iffalse
+
     attr_names = ()
 
 class InitList(Node):
@@ -569,6 +741,10 @@ class InitList(Node):
             nodelist.append(("exprs[%d]" % i, child))
         return tuple(nodelist)
 
+    def __iter__(self):
+        for child in (self.exprs or []):
+            yield child
+
     attr_names = ()
 
 class Label(Node):
@@ -582,6 +758,10 @@ class Label(Node):
         nodelist = []
         if self.stmt is not None: nodelist.append(("stmt", self.stmt))
         return tuple(nodelist)
+
+    def __iter__(self):
+        if self.stmt is not None:
+            yield self.stmt
 
     attr_names = ('name', )
 
@@ -599,6 +779,12 @@ class NamedInitializer(Node):
             nodelist.append(("name[%d]" % i, child))
         return tuple(nodelist)
 
+    def __iter__(self):
+        if self.expr is not None:
+            yield self.expr
+        for child in (self.name or []):
+            yield child
+
     attr_names = ()
 
 class ParamList(Node):
@@ -612,6 +798,10 @@ class ParamList(Node):
         for i, child in enumerate(self.params or []):
             nodelist.append(("params[%d]" % i, child))
         return tuple(nodelist)
+
+    def __iter__(self):
+        for child in (self.params or []):
+            yield child
 
     attr_names = ()
 
@@ -627,6 +817,10 @@ class PtrDecl(Node):
         if self.type is not None: nodelist.append(("type", self.type))
         return tuple(nodelist)
 
+    def __iter__(self):
+        if self.type is not None:
+            yield self.type
+
     attr_names = ('quals', )
 
 class Return(Node):
@@ -639,6 +833,10 @@ class Return(Node):
         nodelist = []
         if self.expr is not None: nodelist.append(("expr", self.expr))
         return tuple(nodelist)
+
+    def __iter__(self):
+        if self.expr is not None:
+            yield self.expr
 
     attr_names = ()
 
@@ -654,6 +852,10 @@ class Struct(Node):
         for i, child in enumerate(self.decls or []):
             nodelist.append(("decls[%d]" % i, child))
         return tuple(nodelist)
+
+    def __iter__(self):
+        for child in (self.decls or []):
+            yield child
 
     attr_names = ('name', )
 
@@ -671,6 +873,12 @@ class StructRef(Node):
         if self.field is not None: nodelist.append(("field", self.field))
         return tuple(nodelist)
 
+    def __iter__(self):
+        if self.name is not None:
+            yield self.name
+        if self.field is not None:
+            yield self.field
+
     attr_names = ('type', )
 
 class Switch(Node):
@@ -685,6 +893,12 @@ class Switch(Node):
         if self.cond is not None: nodelist.append(("cond", self.cond))
         if self.stmt is not None: nodelist.append(("stmt", self.stmt))
         return tuple(nodelist)
+
+    def __iter__(self):
+        if self.cond is not None:
+            yield self.cond
+        if self.stmt is not None:
+            yield self.stmt
 
     attr_names = ()
 
@@ -703,6 +917,14 @@ class TernaryOp(Node):
         if self.iffalse is not None: nodelist.append(("iffalse", self.iffalse))
         return tuple(nodelist)
 
+    def __iter__(self):
+        if self.cond is not None:
+            yield self.cond
+        if self.iftrue is not None:
+            yield self.iftrue
+        if self.iffalse is not None:
+            yield self.iffalse
+
     attr_names = ()
 
 class TypeDecl(Node):
@@ -717,6 +939,10 @@ class TypeDecl(Node):
         nodelist = []
         if self.type is not None: nodelist.append(("type", self.type))
         return tuple(nodelist)
+
+    def __iter__(self):
+        if self.type is not None:
+            yield self.type
 
     attr_names = ('declname', 'quals', )
 
@@ -734,6 +960,10 @@ class Typedef(Node):
         if self.type is not None: nodelist.append(("type", self.type))
         return tuple(nodelist)
 
+    def __iter__(self):
+        if self.type is not None:
+            yield self.type
+
     attr_names = ('name', 'quals', 'storage', )
 
 class Typename(Node):
@@ -749,6 +979,10 @@ class Typename(Node):
         if self.type is not None: nodelist.append(("type", self.type))
         return tuple(nodelist)
 
+    def __iter__(self):
+        if self.type is not None:
+            yield self.type
+
     attr_names = ('name', 'quals', )
 
 class UnaryOp(Node):
@@ -762,6 +996,10 @@ class UnaryOp(Node):
         nodelist = []
         if self.expr is not None: nodelist.append(("expr", self.expr))
         return tuple(nodelist)
+
+    def __iter__(self):
+        if self.expr is not None:
+            yield self.expr
 
     attr_names = ('op', )
 
@@ -778,6 +1016,10 @@ class Union(Node):
             nodelist.append(("decls[%d]" % i, child))
         return tuple(nodelist)
 
+    def __iter__(self):
+        for child in (self.decls or []):
+            yield child
+
     attr_names = ('name', )
 
 class While(Node):
@@ -793,6 +1035,12 @@ class While(Node):
         if self.stmt is not None: nodelist.append(("stmt", self.stmt))
         return tuple(nodelist)
 
+    def __iter__(self):
+        if self.cond is not None:
+            yield self.cond
+        if self.stmt is not None:
+            yield self.stmt
+
     attr_names = ()
 
 class Pragma(Node):
@@ -804,6 +1052,10 @@ class Pragma(Node):
     def children(self):
         nodelist = []
         return tuple(nodelist)
+
+    def __iter__(self):
+        return
+        yield
 
     attr_names = ('string', )
 

--- a/pycparser/c_ast.py
+++ b/pycparser/c_ast.py
@@ -112,25 +112,24 @@ class NodeVisitor(object):
         *   Modeled after Python's own AST visiting facilities
             (the ast module of Python 3.0)
     """
-    
+
     _method_cache = None
-    
+
     def visit(self, node):
         """ Visit a node.
         """
-        
+
         method_cache = self._method_cache
         if method_cache is None:
             method_cache = {}
             self._method_cache = method_cache
-            
+
         visitor = method_cache.get(node.__class__.__name__, None)
         if visitor is None:
             method = 'visit_' + node.__class__.__name__
             visitor = getattr(self, method, self.generic_visit)
-            
             method_cache[node.__class__.__name__] = visitor
-            
+
         return visitor(node)
 
     def generic_visit(self, node):
@@ -139,8 +138,7 @@ class NodeVisitor(object):
         """
         for c in node:
             self.visit(c)
-            
-            
+
 class ArrayDecl(Node):
     __slots__ = ('type', 'dim', 'dim_quals', 'coord', '__weakref__')
     def __init__(self, type, dim, dim_quals, coord=None):


### PR DESCRIPTION
This is a resolution for Issue #219 
Performance improvement can be measured with the following script:
```
with self._open_c_file('cppd_with_stdio_h.c') as f:
    code = f.read()
setup = '''
from pycparser.c_ast import NodeVisitor
from pycparser.c_parser import CParser
code = %r
p = CParser().parse(code)
visitor = NodeVisitor()
''' % (code)
print(timeit.timeit('visitor.visit(p)',
                     setup = setup,
                     number=100))
```

On my workstation, this is twice as fast as the original implementation, while passing all unit tests.

