### PR TITLE
Add support for #pragma in struct_declaration (Issue #221).

### DIFF
--- a/pycparser/c_parser.py
+++ b/pycparser/c_parser.py
@@ -939,6 +939,11 @@ class CParser(PLYParser):
         """
         p[0] = None
 
+    def p_struct_declaration_3(self, p):
+        """ struct_declaration : pppragma_directive
+        """
+        p[0] = [p[1]]
+
     def p_struct_declarator_list(self, p):
         """ struct_declarator_list  : struct_declarator
                                     | struct_declarator_list COMMA struct_declarator

--- a/tests/test_c_generator.py
+++ b/tests/test_c_generator.py
@@ -274,6 +274,9 @@ class TestCtoC(unittest.TestCase):
                 #pragma bar
                 i = (a, b, c);
             }
+            typedef struct s {
+            #pragma baz
+           } s;
         ''')
 
     def test_compound_literal(self):

--- a/tests/test_c_parser.py
+++ b/tests/test_c_parser.py
@@ -1348,6 +1348,9 @@ class TestCParser_fundamentals(TestCParser_base):
                 for(;;) {}
                 #pragma
             }
+            struct s {
+            #pragma baz
+            } s;
             '''
         s1_ast = self.parse(s1)
         self.assertTrue(isinstance(s1_ast.ext[0], Pragma))
@@ -1361,6 +1364,10 @@ class TestCParser_fundamentals(TestCParser_base):
         self.assertTrue(isinstance(s1_ast.ext[1].body.block_items[2], Pragma))
         self.assertEqual(s1_ast.ext[1].body.block_items[2].string, '')
         self.assertEqual(s1_ast.ext[1].body.block_items[2].coord.line, 6)
+        
+        self.assertTrue(isinstance(s1_ast.ext[2].type.type.decls[0], Pragma))
+        self.assertEqual(s1_ast.ext[2].type.type.decls[0].string, 'baz')
+        self.assertEqual(s1_ast.ext[2].type.type.decls[0].coord.line, 9)
 
 
 class TestCParser_whole_code(TestCParser_base):


### PR DESCRIPTION
Support `#pragma` within a `struct`

Note: On first run (when `lextab.py`/`yacctab.py` do not exist yet), I get the following message:
```
Generating LALR tables
WARNING: 1 shift/reduce conflict
```
As this also happens on master, I assume this is OK.
