### PR TITLE
Add missing fake_libc_includes for POSIX.1-2008 compatibility

### DIFF
--- a/utils/fake_libc_include/aio.h
+++ b/utils/fake_libc_include/aio.h
@@ -1,0 +1,2 @@
+#include "_fake_defines.h"
+#include "_fake_typedefs.h"

--- a/utils/fake_libc_include/cpio.h
+++ b/utils/fake_libc_include/cpio.h
@@ -1,0 +1,2 @@
+#include "_fake_defines.h"
+#include "_fake_typedefs.h"

--- a/utils/fake_libc_include/fmtmsg.h
+++ b/utils/fake_libc_include/fmtmsg.h
@@ -1,0 +1,2 @@
+#include "_fake_defines.h"
+#include "_fake_typedefs.h"

--- a/utils/fake_libc_include/fnmatch.h
+++ b/utils/fake_libc_include/fnmatch.h
@@ -1,0 +1,2 @@
+#include "_fake_defines.h"
+#include "_fake_typedefs.h"

--- a/utils/fake_libc_include/ftw.h
+++ b/utils/fake_libc_include/ftw.h
@@ -1,0 +1,2 @@
+#include "_fake_defines.h"
+#include "_fake_typedefs.h"

--- a/utils/fake_libc_include/glob.h
+++ b/utils/fake_libc_include/glob.h
@@ -1,0 +1,2 @@
+#include "_fake_defines.h"
+#include "_fake_typedefs.h"

--- a/utils/fake_libc_include/monetary.h
+++ b/utils/fake_libc_include/monetary.h
@@ -1,0 +1,2 @@
+#include "_fake_defines.h"
+#include "_fake_typedefs.h"

--- a/utils/fake_libc_include/mqueue.h
+++ b/utils/fake_libc_include/mqueue.h
@@ -1,0 +1,2 @@
+#include "_fake_defines.h"
+#include "_fake_typedefs.h"

--- a/utils/fake_libc_include/ndbm.h
+++ b/utils/fake_libc_include/ndbm.h
@@ -1,0 +1,2 @@
+#include "_fake_defines.h"
+#include "_fake_typedefs.h"

--- a/utils/fake_libc_include/net/if.h
+++ b/utils/fake_libc_include/net/if.h
@@ -1,0 +1,2 @@
+#include "_fake_defines.h"
+#include "_fake_typedefs.h"

--- a/utils/fake_libc_include/nl_types.h
+++ b/utils/fake_libc_include/nl_types.h
@@ -1,0 +1,2 @@
+#include "_fake_defines.h"
+#include "_fake_typedefs.h"

--- a/utils/fake_libc_include/poll.h
+++ b/utils/fake_libc_include/poll.h
@@ -1,0 +1,2 @@
+#include "_fake_defines.h"
+#include "_fake_typedefs.h"

--- a/utils/fake_libc_include/spawn.h
+++ b/utils/fake_libc_include/spawn.h
@@ -1,0 +1,2 @@
+#include "_fake_defines.h"
+#include "_fake_typedefs.h"

--- a/utils/fake_libc_include/strings.h
+++ b/utils/fake_libc_include/strings.h
@@ -1,0 +1,2 @@
+#include "_fake_defines.h"
+#include "_fake_typedefs.h"

--- a/utils/fake_libc_include/stropts.h
+++ b/utils/fake_libc_include/stropts.h
@@ -1,0 +1,2 @@
+#include "_fake_defines.h"
+#include "_fake_typedefs.h"

--- a/utils/fake_libc_include/sys/ipc.h
+++ b/utils/fake_libc_include/sys/ipc.h
@@ -1,0 +1,2 @@
+#include "_fake_defines.h"
+#include "_fake_typedefs.h"

--- a/utils/fake_libc_include/sys/msg.h
+++ b/utils/fake_libc_include/sys/msg.h
@@ -1,0 +1,2 @@
+#include "_fake_defines.h"
+#include "_fake_typedefs.h"

--- a/utils/fake_libc_include/sys/sem.h
+++ b/utils/fake_libc_include/sys/sem.h
@@ -1,0 +1,2 @@
+#include "_fake_defines.h"
+#include "_fake_typedefs.h"

--- a/utils/fake_libc_include/sys/shm.h
+++ b/utils/fake_libc_include/sys/shm.h
@@ -1,0 +1,2 @@
+#include "_fake_defines.h"
+#include "_fake_typedefs.h"

--- a/utils/fake_libc_include/sys/statvfs.h
+++ b/utils/fake_libc_include/sys/statvfs.h
@@ -1,0 +1,2 @@
+#include "_fake_defines.h"
+#include "_fake_typedefs.h"

--- a/utils/fake_libc_include/sys/times.h
+++ b/utils/fake_libc_include/sys/times.h
@@ -1,0 +1,2 @@
+#include "_fake_defines.h"
+#include "_fake_typedefs.h"

--- a/utils/fake_libc_include/trace.h
+++ b/utils/fake_libc_include/trace.h
@@ -1,0 +1,2 @@
+#include "_fake_defines.h"
+#include "_fake_typedefs.h"

--- a/utils/fake_libc_include/ulimit.h
+++ b/utils/fake_libc_include/ulimit.h
@@ -1,0 +1,2 @@
+#include "_fake_defines.h"
+#include "_fake_typedefs.h"

--- a/utils/fake_libc_include/utmpx.h
+++ b/utils/fake_libc_include/utmpx.h
@@ -1,0 +1,2 @@
+#include "_fake_defines.h"
+#include "_fake_typedefs.h"

--- a/utils/fake_libc_include/wordexp.h
+++ b/utils/fake_libc_include/wordexp.h
@@ -1,0 +1,2 @@
+#include "_fake_defines.h"
+#include "_fake_typedefs.h"


### PR DESCRIPTION
Various fake libc includes were missing according the POSIX.1-2008 standard. Add those.
See http://pubs.opengroup.org/onlinepubs/9699919799/ and specifically http://pubs.opengroup.org/onlinepubs/9699919799/idx/head.html