### PR TITLE
Extend Xlib objects in fake includes

### DIFF
--- a/utils/fake_libc_include/X11/Xlib.h
+++ b/utils/fake_libc_include/X11/Xlib.h
@@ -1,2 +1,3 @@
 #include "_fake_defines.h"
 #include "_fake_typedefs.h"
+#include "_fake_function_declarations.h"

--- a/utils/fake_libc_include/_fake_defines.h
+++ b/utils/fake_libc_include/_fake_defines.h
@@ -43,4 +43,14 @@ typedef int va_list;
 #define va_arg(_ap, _type) __builtin_va_arg((_ap))
 #define va_end(_list)
 
+/* X11 defines */
+#define Atom CARD32
+#define Bool int
+#define KeySym CARD32
+#define Pixmap CARD32
+#define Time CARD32
+#define _XFUNCPROTOBEGIN
+#define _XFUNCPROTOEND
+#define _Xconst const
+
 #endif

--- a/utils/fake_libc_include/_fake_function_declarations.h
+++ b/utils/fake_libc_include/_fake_function_declarations.h
@@ -1,0 +1,23 @@
+#ifndef _FAKE_FUNCTION_DECLARATIONS_H
+#define _FAKE_FUNCTION_DECLARATIONS_H
+
+#include "_fake_defines.h"
+#include "_fake_typedefs.h"
+
+Status XGetClassHint(
+    Display*      /* display */,
+    Window     /* w */,
+    XClassHint*      /* class_hints_return */
+);
+
+Screen *XtScreen(
+    Widget     /* widget */
+);
+
+XSelectionRequestEvent *XtGetSelectionRequest(
+    Widget 		/* widget */,
+    Atom 		/* selection */,
+    XtRequestId 	/* request_id */
+);
+
+#endif

--- a/utils/fake_libc_include/_fake_typedefs.h
+++ b/utils/fake_libc_include/_fake_typedefs.h
@@ -153,10 +153,38 @@ typedef _Bool bool;
 typedef int va_list;
 
 /* Xlib objects */
-typedef struct Display Display;
-typedef unsigned long XID;
+typedef char * XPointer;
+typedef unsigned char KeyCode;
+typedef unsigned int  CARD32;
 typedef unsigned long VisualID;
+typedef unsigned long XIMResetState;
+typedef unsigned long XID;
 typedef XID Window;
+typedef XID Colormap;
+typedef XID Cursor;
+typedef XID Drawable;
+typedef void*		XtPointer;
+typedef XtPointer XtRequestId;
+typedef struct Display Display;
+typedef struct Screen Screen;
+typedef struct Status Status;
+typedef struct Visual Visual;
+typedef struct Widget *Widget;
+typedef struct XColor XColor;
+typedef struct XEvent XEvent;
+typedef struct XFontStruct XFontStruct;
+typedef struct XGCValues XGCValues;
+typedef struct XKeyEvent XKeyEvent;
+typedef struct XKeyPressedEvent XKeyPressedEvent;
+typedef struct XPoint XPoint;
+typedef struct XRectangle XRectangle;
+typedef struct XSelectionRequestEvent XSelectionRequestEvent;
+typedef struct XWindowChanges XWindowChanges;
+typedef struct _XGC _XCG;
+typedef struct _XGC *GC;
+typedef struct _XIC *XIC;
+typedef struct _XIM *XIM;
+typedef struct _XImage XImage;
 
 /* Mir typedefs */
 typedef void* MirEGLNativeWindowType;


### PR DESCRIPTION
Extend the Xlib objects. Needed for a package using a wider range of Xlib items.