### PR TITLE
Fixing redefinition in Fake Headers.

### DIFF
--- a/utils/fake_libc_include/_fake_defines.h
+++ b/utils/fake_libc_include/_fake_defines.h
@@ -194,7 +194,6 @@
 #define true 1
 
 /* va_arg macros and type*/
-typedef int va_list;
 #define va_start(_ap, _type) __builtin_va_start((_ap))
 #define va_arg(_ap, _type) __builtin_va_arg((_ap))
 #define va_end(_list)

--- a/utils/fake_libc_include/_fake_typedefs.h
+++ b/utils/fake_libc_include/_fake_typedefs.h
@@ -4,6 +4,7 @@
 typedef int size_t;
 typedef int __builtin_va_list;
 typedef int __gnuc_va_list;
+typedef int va_list;
 typedef int __int8_t;
 typedef int __uint8_t;
 typedef int __int16_t;

--- a/utils/fake_libc_include/_fake_typedefs.h
+++ b/utils/fake_libc_include/_fake_typedefs.h
@@ -2,6 +2,7 @@
 #define _FAKE_TYPEDEFS_H
 
 typedef int size_t;
+typedef int __builtin_va_list;
 typedef int __gnuc_va_list;
 typedef int __int8_t;
 typedef int __uint8_t;

--- a/utils/fake_libc_include/_fake_typedefs.h
+++ b/utils/fake_libc_include/_fake_typedefs.h
@@ -2,7 +2,6 @@
 #define _FAKE_TYPEDEFS_H
 
 typedef int size_t;
-typedef int __builtin_va_list;
 typedef int __gnuc_va_list;
 typedef int __int8_t;
 typedef int __uint8_t;
@@ -149,8 +148,6 @@ typedef int uintmax_t;
 
 /* C99 stdbool.h bool type. _Bool is built-in in C99 */
 typedef _Bool bool;
-
-typedef int va_list;
 
 /* Mir typedefs */
 typedef void* MirEGLNativeWindowType;


### PR DESCRIPTION
Currently, both `_fake_typedefs.h` and `_fake_defines.h` define `__builtin_va_list` and `va_list`.
A case could be made for having them in either file. I don't really care which file they are defined in, I just don't want it to be in both of them, because its a redefinition error.