### PR TITLE
Add additional trove classifiers to setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -47,6 +47,8 @@ setup(
     url='https://github.com/eliben/pycparser',
     platforms='Cross Platform',
     classifiers = [
+        'Development Status :: 5 - Production/Stable',
+        'License :: OSI Approved :: BSD License',
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',


### PR DESCRIPTION
- Document project as stable, ready for use in production environments
- Document project license

Helps library users know these values at a glance. These classifiers are displayed on the PyPI page:

https://pypi.python.org/pypi/pycparser

For a complete list of trove classifiers, see:

https://pypi.python.org/pypi?%3Aaction=list_classifiers