### PR TITLE
Add support for empty struct (#66)

### DIFF
--- a/pycparser/c_generator.py
+++ b/pycparser/c_generator.py
@@ -300,10 +300,12 @@ class CGenerator(object):
             body_function = self._generate_struct_union_body
         else:
             assert name == 'enum'
-            members = () if n.values is None else n.values.enumerators
+            members = None if n.values is None else n.values.enumerators
             body_function = self._generate_enum_body
         s = name + ' ' + (n.name or '')
         if members is not None:
+            # None means no members
+            # Empty sequence means an empty list of members
             s += '\n'
             s += self._make_indent()
             self.indent_level += 2

--- a/pycparser/c_generator.py
+++ b/pycparser/c_generator.py
@@ -303,7 +303,7 @@ class CGenerator(object):
             members = () if n.values is None else n.values.enumerators
             body_function = self._generate_enum_body
         s = name + ' ' + (n.name or '')
-        if members:
+        if members is not None:
             s += '\n'
             s += self._make_indent()
             self.indent_level += 2

--- a/pycparser/c_parser.py
+++ b/pycparser/c_parser.py
@@ -908,6 +908,7 @@ class CParser(PLYParser):
                                         | struct_or_union TYPEID
         """
         klass = self._select_struct_union_class(p[1])
+        # None means no list of members
         p[0] = klass(
             name=p[2],
             decls=None,
@@ -919,7 +920,6 @@ class CParser(PLYParser):
         """
         klass = self._select_struct_union_class(p[1])
         if len(p) == 4:
-            # None means no members
             # Empty sequence means an empty list of members
             p[0] = klass(
                 name=None,
@@ -940,7 +940,6 @@ class CParser(PLYParser):
         """
         klass = self._select_struct_union_class(p[1])
         if len(p) == 5:
-            # None means no members
             # Empty sequence means an empty list of members
             p[0] = klass(
                 name=p[2],

--- a/pycparser/c_parser.py
+++ b/pycparser/c_parser.py
@@ -102,8 +102,7 @@ class CParser(PLYParser):
             'parameter_type_list',
             'block_item_list',
             'type_qualifier_list',
-            'struct_declarator_list',
-            'struct_declaration_list',
+            'struct_declarator_list'
         ]
 
         for rule in rules_with_opt:
@@ -915,7 +914,8 @@ class CParser(PLYParser):
             coord=self._token_coord(p, 2))
 
     def p_struct_or_union_specifier_2(self, p):
-        """ struct_or_union_specifier : struct_or_union brace_open struct_declaration_list_opt brace_close
+        """ struct_or_union_specifier : struct_or_union brace_open struct_declaration_list brace_close
+                                      | struct_or_union brace_open brace_close
         """
         klass = self._select_struct_union_class(p[1])
         if len(p) == 4:
@@ -933,8 +933,10 @@ class CParser(PLYParser):
 
 
     def p_struct_or_union_specifier_3(self, p):
-        """ struct_or_union_specifier   : struct_or_union ID brace_open struct_declaration_list_opt brace_close
-                                        | struct_or_union TYPEID brace_open struct_declaration_list_opt brace_close
+        """ struct_or_union_specifier   : struct_or_union ID brace_open struct_declaration_list brace_close
+                                        | struct_or_union ID brace_open brace_close
+                                        | struct_or_union TYPEID brace_open struct_declaration_list brace_close
+                                        | struct_or_union TYPEID brace_open brace_close
         """
         klass = self._select_struct_union_class(p[1])
         if len(p) == 5:

--- a/pycparser/c_parser.py
+++ b/pycparser/c_parser.py
@@ -923,14 +923,23 @@ class CParser(PLYParser):
             coord=self._token_coord(p, 2))
 
     def p_struct_or_union_specifier_3(self, p):
-        """ struct_or_union_specifier   : struct_or_union ID brace_open struct_declaration_list brace_close
+        """ struct_or_union_specifier   : struct_or_union ID brace_open brace_close
+                                        | struct_or_union ID brace_open struct_declaration_list brace_close
+                                        | struct_or_union TYPEID brace_open brace_close
                                         | struct_or_union TYPEID brace_open struct_declaration_list brace_close
         """
         klass = self._select_struct_union_class(p[1])
-        p[0] = klass(
-            name=p[2],
-            decls=p[4],
-            coord=self._token_coord(p, 2))
+        if len(p) == 6:
+            p[0] = klass(
+                name=p[2],
+                decls=p[4],
+                coord=self._token_coord(p, 2))
+        else:
+            # Empty structs are not pure-C99, but accepted.
+            p[0] = klass(
+                name=p[2],
+                decls=[],
+                coord=self._token_coord(p, 2))
 
     def p_struct_or_union(self, p):
         """ struct_or_union : STRUCT

--- a/tests/test_c_generator.py
+++ b/tests/test_c_generator.py
@@ -213,6 +213,18 @@ class TestCtoC(unittest.TestCase):
               return 0;
             }''')
 
+    def test_issue66(self):
+        # A non-existing body must not be generated
+        # (previous valid behavior, still working)
+        self._assert_ctoc_correct(r'''
+            struct foo;
+            ''')
+        # An empty body must be generated
+        # (added behavior)
+        self._assert_ctoc_correct(r'''
+            struct foo {};
+            ''')
+
     def test_issue83(self):
         self._assert_ctoc_correct(r'''
             void x(void) {

--- a/tests/test_c_parser.py
+++ b/tests/test_c_parser.py
@@ -998,6 +998,26 @@ class TestCParser_fundamentals(TestCParser_base):
         self.assertEqual(parsed_struct.type.type.decls[0].bitsize.value, '6')
         self.assertEqual(parsed_struct.type.type.decls[1].bitsize.value, '2')
 
+    def test_struct_empty(self):
+        """
+        Tests that parsing an empty struct works.
+        
+        Empty structs do NOT follow C99 (See 6.2.5-20 of the C99 standard).
+        This is nevertheless supported by some compilers (clang, gcc), 
+        especially when using FORTIFY code. 
+        Some compilers (visual) will fail to compile with an error.
+        """
+        # an empty struct. This is NOT C99 compliant
+        s1 = """
+                 struct foo { };
+             """
+
+        parsed_struct = self.parse(s1).ext[0]
+
+        self.assertEqual(expand_decl(parsed_struct),
+                         ['Decl', None, ['Struct', 'foo', []]]
+                         )
+
     def test_tags_namespace(self):
         """ Tests that the tags of structs/unions/enums reside in a separate namespace and
             can be named after existing types.


### PR DESCRIPTION
Support empty `struct` in parser and c generator.

Though not allowed by C99, empty `struct`s can be found in android headers.
(Look for `__bionic_zero_size_is_okay_t` in android code).

Note: 
Issue #66 was closed because the original poster found a workaround. 
As @eliben welcomed pull requests in comments, #66 could be reopened/reclosed as fixed.