### PR TITLE
Fix non-generated constant expressions in designated initializers (#246)

### DIFF
--- a/pycparser/c_generator.py
+++ b/pycparser/c_generator.py
@@ -283,8 +283,8 @@ class CGenerator(object):
         for name in n.name:
             if isinstance(name, c_ast.ID):
                 s += '.' + name.name
-            elif isinstance(name, c_ast.Constant):
-                s += '[' + name.value + ']'
+            else:
+                s += '[' + self.visit(name) + ']'
         s += ' = ' + self._visit_expr(n.expr)
         return s
 

--- a/tests/test_c_generator.py
+++ b/tests/test_c_generator.py
@@ -228,6 +228,11 @@ class TestCtoC(unittest.TestCase):
             }
             ''')
 
+    def test_issue246(self):
+        self._assert_ctoc_correct(r'''
+            int array[3] = {[0] = 0, [1] = 1, [1+1] = 2};
+            ''')
+
     def test_exprlist_with_semi(self):
         self._assert_ctoc_correct(r'''
             void x() {


### PR DESCRIPTION
Adds a visitor call on non-`ID` names in `CGenerator.visit_NamedInitializer` (Fix #246).