### PR TITLE
Replace a call to Popen by check_output in order to check that cpp returns 0.

### DIFF
--- a/pycparser/__init__.py
+++ b/pycparser/__init__.py
@@ -10,7 +10,7 @@
 __all__ = ['c_lexer', 'c_parser', 'c_ast']
 __version__ = '2.18'
 
-from subprocess import Popen, PIPE
+from subprocess import check_output
 from .c_parser import CParser
 
 
@@ -39,10 +39,7 @@ def preprocess_file(filename, cpp_path='cpp', cpp_args=''):
         # Note the use of universal_newlines to treat all newlines
         # as \n for Python's purpose
         #
-        pipe = Popen(   path_list,
-                        stdout=PIPE,
-                        universal_newlines=True)
-        text = pipe.communicate()[0]
+        text = check_output(path_list, universal_newlines=True)
     except OSError as e:
         raise RuntimeError("Unable to invoke 'cpp'.  " +
             'Make sure its path was passed correctly\n' +


### PR DESCRIPTION
At the moment, if cpp fails, no error/exception is generated and pycparser continues.
Calling check_output instead of Popen solves this.