### PR TITLE
Remove unnecessary __future__ import

### DIFF
--- a/pycparser/ply/cpp.py
+++ b/pycparser/ply/cpp.py
@@ -7,8 +7,6 @@
 #
 # This module implements an ANSI-C style lexical preprocessor for PLY.
 # -----------------------------------------------------------------------------
-from __future__ import generators
-
 import sys
 
 # Some Python 3 compatibility shims


### PR DESCRIPTION
Generators have been available since 2.3. The feature is automatically included in all supported Pythons.

For additional details, see:

https://docs.python.org/3/library/__future__.html