### PR TITLE
Avoid opening files with deprecated 'U' mode

### DIFF
--- a/pycparser/__init__.py
+++ b/pycparser/__init__.py
@@ -10,6 +10,7 @@
 __all__ = ['c_lexer', 'c_parser', 'c_ast']
 __version__ = '2.18'
 
+import io
 from subprocess import check_output
 from .c_parser import CParser
 
@@ -81,7 +82,7 @@ def parse_file(filename, use_cpp=False, cpp_path='cpp', cpp_args='',
     if use_cpp:
         text = preprocess_file(filename, cpp_path, cpp_args)
     else:
-        with open(filename, 'rU') as f:
+        with io.open(filename) as f:
             text = f.read()
 
     if parser is None:

--- a/tests/test_c_parser.py
+++ b/tests/test_c_parser.py
@@ -3,6 +3,7 @@
 import pprint
 import re
 import os, sys
+import io
 import unittest
 
 sys.path[0:0] = ['.', '..']
@@ -1772,7 +1773,7 @@ class TestCParser_whole_code(TestCParser_base):
         testdir = os.path.dirname(__file__)
         name = os.path.join(testdir, 'c_files', name)
         assert os.path.exists(name)
-        return open(name, 'rU')
+        return io.open(name)
 
     def test_whole_file(self):
         # See how pycparser handles a whole, real C file.


### PR DESCRIPTION
Opening files with 'U' mode is deprecated. When running tests with Python warnings enabled, the warnings of the following form are emitted:

```
  DeprecationWarning: 'U' mode is deprecated
    return open(name, 'rU')
```

To open files with universal newlines on both Ptyhon 2 & 3, use the io module. It defaults to opening with universal newlines and doesn't emit a warning.

https://docs.python.org/3/library/io.html

> When reading input from the stream, if newline is None, universal newlines mode is enabled.