### PR TITLE
Correct Parsing of Floating Point Literals, issue #253

### DIFF
--- a/pycparser/c_parser.py
+++ b/pycparser/c_parser.py
@@ -1774,8 +1774,18 @@ class CParser(PLYParser):
         """ constant    : FLOAT_CONST
                         | HEX_FLOAT_CONST
         """
+        if 'x' in p[1].lower():
+            t = 'float'
+        else:
+            if p[1][-1] in ('f', 'F'):
+                t = 'float'
+            elif p[1][-1] in ('l', 'L'):
+                t = 'long double'
+            else:
+                t = 'double'
+
         p[0] = c_ast.Constant(
-            'float', p[1], self._token_coord(p, 1))
+            t, p[1], self._token_coord(p, 1))
 
     def p_constant_3(self, p):
         """ constant    : CHAR_CONST

--- a/tests/test_c_parser.py
+++ b/tests/test_c_parser.py
@@ -1216,6 +1216,27 @@ class TestCParser_fundamentals(TestCParser_base):
                  ['Constant', 'int', '5']],
                 ['Constant', 'int', '6']])
 
+        d5 = 'float d = 1.0;'
+        self.assertEqual(self.get_decl_init(d5),
+            ['Constant', 'double', '1.0'])
+
+        d51 = 'float ld = 1.0l;'
+        self.assertEqual(self.get_decl_init(d51),
+            ['Constant', 'long double', '1.0l'])
+
+        d52 = 'float ld = 1.0L;'
+        self.assertEqual(self.get_decl_init(d52),
+            ['Constant', 'long double', '1.0L'])
+
+        d53 = 'float ld = 1.0f;'
+        self.assertEqual(self.get_decl_init(d53),
+            ['Constant', 'float', '1.0f'])
+
+        d54 = 'float ld = 1.0F;'
+        self.assertEqual(self.get_decl_init(d54),
+            ['Constant', 'float', '1.0F'])
+
+
     def test_decl_named_inits(self):
         d1 = 'int a = {.k = 16};'
         self.assertEqual(self.get_decl_init(d1),


### PR DESCRIPTION
This sets the type attribute to either 'float', 'long double' or 'double' depending on if 'f|F', 'l|L' or '' is specified at the end of the constant definition. This should fix issue #253 .