### PR TITLE
Fix encoding problem by adding `encoding` parameter to parse_file function

### DIFF
--- a/pycparser/__init__.py
+++ b/pycparser/__init__.py
@@ -15,7 +15,7 @@ from subprocess import check_output
 from .c_parser import CParser
 
 
-def preprocess_file(filename, cpp_path='cpp', cpp_args=''):
+def preprocess_file(filename, cpp_path='cpp', cpp_args='', encoding=None):
     """ Preprocess a file using cpp.
 
         filename:
@@ -25,6 +25,9 @@ def preprocess_file(filename, cpp_path='cpp', cpp_args=''):
         cpp_args:
             Refer to the documentation of parse_file for the meaning of these
             arguments.
+
+        encoding:
+            The encoding of the input file `filename`.
 
         When successful, returns the preprocessed file's contents.
         Errors from cpp will be printed out.
@@ -39,7 +42,7 @@ def preprocess_file(filename, cpp_path='cpp', cpp_args=''):
     try:
         # Note the use of universal_newlines to treat all newlines
         # as \n for Python's purpose
-        text = check_output(path_list, universal_newlines=True)
+        text = check_output(path_list, universal_newlines=True, encoding=encoding)
     except OSError as e:
         raise RuntimeError("Unable to invoke 'cpp'.  " +
             'Make sure its path was passed correctly\n' +
@@ -49,7 +52,7 @@ def preprocess_file(filename, cpp_path='cpp', cpp_args=''):
 
 
 def parse_file(filename, use_cpp=False, cpp_path='cpp', cpp_args='',
-               parser=None):
+               parser=None, encoding=None):
     """ Parse a C file using pycparser.
 
         filename:
@@ -71,6 +74,9 @@ def parse_file(filename, use_cpp=False, cpp_path='cpp', cpp_args='',
             r'-I../utils/fake_libc_include'
             If several arguments are required, pass a list of strings.
 
+        encoding:
+            The encoding of the input file `filename`.
+
         parser:
             Optional parser object to be used instead of the default CParser
 
@@ -80,7 +86,7 @@ def parse_file(filename, use_cpp=False, cpp_path='cpp', cpp_args='',
         Errors from cpp will be printed out.
     """
     if use_cpp:
-        text = preprocess_file(filename, cpp_path, cpp_args)
+        text = preprocess_file(filename, cpp_path, cpp_args, encoding)
     else:
         with io.open(filename) as f:
             text = f.read()


### PR DESCRIPTION
Fixes #293

Description:
For some Chinese Unicode c files, parse_file may fail if not providing proper `encoding` information. Adding `encoding` parameter will give users the option of providing correct file encoding.