### PR TITLE
C_generator arrayRef subscript fix

### DIFF
--- a/pycparser/c_generator.py
+++ b/pycparser/c_generator.py
@@ -48,7 +48,7 @@ class CGenerator(object):
 
     def visit_ArrayRef(self, n):
         arrref = self._parenthesize_unless_simple(n.name)
-        return arrref + '[' + self.visit(n.subscript) + ']'
+        return arrref + '[' + str(self.visit(n.subscript)) + ']'
 
     def visit_StructRef(self, n):
         sref = self._parenthesize_unless_simple(n.name)


### PR DESCRIPTION
If the subscript of an ArrayRef is a constant, the c_generator fails (as '+' cannot be used on a string and an int in python.