### PR TITLE
Fix array type generation (#312)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,4 +14,4 @@ parser.out
 .tox
 utils/z.c
 *.egg-info
-
+*.swp

--- a/pycparser/c_generator.py
+++ b/pycparser/c_generator.py
@@ -292,10 +292,17 @@ class CGenerator(object):
         return self._generate_type(n)
 
     def visit_ArrayDecl(self, n):
-        s = self.visit(n.type) + '['
+        s = ''
+        s += self.visit(n.type) + '['
         if n.dim_quals: s += ' '.join(n.dim_quals) + ' '
         if n.dim: s += self.visit(n.dim)
         s += ']'
+        return s
+
+    def visit_TypeDecl(self, n):
+        s = ''
+        if n.quals: s += ' '.join(n.quals) + ' '
+        s += self.visit(n.type)
         return s
 
     def _generate_struct_union_enum(self, n, name):

--- a/pycparser/c_generator.py
+++ b/pycparser/c_generator.py
@@ -291,6 +291,13 @@ class CGenerator(object):
     def visit_FuncDecl(self, n):
         return self._generate_type(n)
 
+    def visit_ArrayDecl(self, n):
+        s = self.visit(n.type) + '['
+        if n.dim_quals: s += ' '.join(n.dim_quals) + ' '
+        if n.dim: s += self.visit(n.dim)
+        s += ']'
+        return s
+
     def _generate_struct_union_enum(self, n, name):
         """ Generates code for structs, unions, and enums. name should be
             'struct', 'union', or 'enum'.
@@ -382,7 +389,9 @@ class CGenerator(object):
                 if isinstance(modifier, c_ast.ArrayDecl):
                     if (i != 0 and isinstance(modifiers[i - 1], c_ast.PtrDecl)):
                         nstr = '(' + nstr + ')'
-                    nstr += '[' + self.visit(modifier.dim) + ']'
+                    nstr += '['
+                    if modifier.dim_quals: nstr += ' '.join(modifier.dim_quals) + ' '
+                    nstr += self.visit(modifier.dim) + ']'
                 elif isinstance(modifier, c_ast.FuncDecl):
                     if (i != 0 and isinstance(modifiers[i - 1], c_ast.PtrDecl)):
                         nstr = '(' + nstr + ')'

--- a/tests/test_c_generator.py
+++ b/tests/test_c_generator.py
@@ -332,6 +332,12 @@ class TestCtoC(unittest.TestCase):
             name='',
         )
 
+    def test_array_decl(self):
+        self._assert_ctoc_correct('int g(const int a[const 20]){}')
+        ast = parse_to_ast('const int a[const 20];')
+        generator = c_generator.CGenerator()
+        self.assertEqual(generator.visit(ast.ext[0].type), 'const int[const 20]')
+        self.assertEqual(generator.visit(ast.ext[0].type.type), 'const int')
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Also added `dim_quals` handling to `_generate_type`

Exmaple:

```python
>>> ast = parser.parse('int g(const int a[const 20]){}')
>>> gen.visit(ast.ext[0].decl.type.args.params[0])
'const int a[const 20]'
>>> gen.visit(ast.ext[0].decl.type.args.params[0].type)
'int[const 20]'
```