### PR TITLE
Generate pointer types correctly

### DIFF
--- a/pycparser/c_generator.py
+++ b/pycparser/c_generator.py
@@ -292,18 +292,13 @@ class CGenerator(object):
         return self._generate_type(n)
 
     def visit_ArrayDecl(self, n):
-        s = ''
-        s += self.visit(n.type) + '['
-        if n.dim_quals: s += ' '.join(n.dim_quals) + ' '
-        if n.dim: s += self.visit(n.dim)
-        s += ']'
-        return s
-
+        return self._generate_type(n, emit_declname=False)
+        
     def visit_TypeDecl(self, n):
-        s = ''
-        if n.quals: s += ' '.join(n.quals) + ' '
-        s += self.visit(n.type)
-        return s
+        return self._generate_type(n, emit_declname=False)
+        
+    def visit_PtrDecl(self, n):
+        return self._generate_type(n, emit_declname=False)
 
     def _generate_struct_union_enum(self, n, name):
         """ Generates code for structs, unions, and enums. name should be
@@ -373,7 +368,7 @@ class CGenerator(object):
         s += self._generate_type(n.type)
         return s
 
-    def _generate_type(self, n, modifiers=[]):
+    def _generate_type(self, n, modifiers=[], emit_declname = True):
         """ Recursive generation from a type node. n is the type node.
             modifiers collects the PtrDecl, ArrayDecl and FuncDecl modifiers
             encountered on the way down to a TypeDecl, to allow proper
@@ -387,7 +382,7 @@ class CGenerator(object):
             if n.quals: s += ' '.join(n.quals) + ' '
             s += self.visit(n.type)
 
-            nstr = n.declname if n.declname else ''
+            nstr = n.declname if n.declname and emit_declname else ''
             # Resolve modifiers.
             # Wrap in parens to distinguish pointer to array and pointer to
             # function syntax.
@@ -405,7 +400,7 @@ class CGenerator(object):
                     nstr += '(' + self.visit(modifier.args) + ')'
                 elif isinstance(modifier, c_ast.PtrDecl):
                     if modifier.quals:
-                        nstr = '* %s %s' % (' '.join(modifier.quals), nstr)
+                        nstr = '* %s%s' % (' '.join(modifier.quals), ' ' + nstr if nstr else '')
                     else:
                         nstr = '*' + nstr
             if nstr: s += ' ' + nstr
@@ -413,11 +408,11 @@ class CGenerator(object):
         elif typ == c_ast.Decl:
             return self._generate_decl(n.type)
         elif typ == c_ast.Typename:
-            return self._generate_type(n.type)
+            return self._generate_type(n.type, emit_declname = emit_declname)
         elif typ == c_ast.IdentifierType:
             return ' '.join(n.names) + ' '
         elif typ in (c_ast.ArrayDecl, c_ast.PtrDecl, c_ast.FuncDecl):
-            return self._generate_type(n.type, modifiers + [n])
+            return self._generate_type(n.type, modifiers + [n], emit_declname = emit_declname)
         else:
             return self.visit(n)
 

--- a/pycparser/c_generator.py
+++ b/pycparser/c_generator.py
@@ -389,18 +389,22 @@ class CGenerator(object):
             #
             for i, modifier in enumerate(modifiers):
                 if isinstance(modifier, c_ast.ArrayDecl):
-                    if (i != 0 and isinstance(modifiers[i - 1], c_ast.PtrDecl)):
-                        nstr = '(' + nstr + ')'
+                    if (i != 0 and 
+                        isinstance(modifiers[i - 1], c_ast.PtrDecl)):
+                            nstr = '(' + nstr + ')'
                     nstr += '['
-                    if modifier.dim_quals: nstr += ' '.join(modifier.dim_quals) + ' '
+                    if modifier.dim_quals:
+                        nstr += ' '.join(modifier.dim_quals) + ' '
                     nstr += self.visit(modifier.dim) + ']'
                 elif isinstance(modifier, c_ast.FuncDecl):
-                    if (i != 0 and isinstance(modifiers[i - 1], c_ast.PtrDecl)):
-                        nstr = '(' + nstr + ')'
+                    if (i != 0 and 
+                        isinstance(modifiers[i - 1], c_ast.PtrDecl)):
+                            nstr = '(' + nstr + ')'
                     nstr += '(' + self.visit(modifier.args) + ')'
                 elif isinstance(modifier, c_ast.PtrDecl):
                     if modifier.quals:
-                        nstr = '* %s%s' % (' '.join(modifier.quals), ' ' + nstr if nstr else '')
+                        nstr = '* %s%s' % (' '.join(modifier.quals), 
+                                           ' ' + nstr if nstr else '')
                     else:
                         nstr = '*' + nstr
             if nstr: s += ' ' + nstr
@@ -412,7 +416,8 @@ class CGenerator(object):
         elif typ == c_ast.IdentifierType:
             return ' '.join(n.names) + ' '
         elif typ in (c_ast.ArrayDecl, c_ast.PtrDecl, c_ast.FuncDecl):
-            return self._generate_type(n.type, modifiers + [n], emit_declname = emit_declname)
+            return self._generate_type(n.type, modifiers + [n],
+                                       emit_declname = emit_declname)
         else:
             return self.visit(n)
 

--- a/tests/test_c_generator.py
+++ b/tests/test_c_generator.py
@@ -336,17 +336,22 @@ class TestCtoC(unittest.TestCase):
         self._assert_ctoc_correct('int g(const int a[const 20]){}')
         ast = parse_to_ast('const int a[const 20];')
         generator = c_generator.CGenerator()
-        self.assertEqual(generator.visit(ast.ext[0].type), 'const int [const 20]')
-        self.assertEqual(generator.visit(ast.ext[0].type.type), 'const int')
+        self.assertEqual(generator.visit(ast.ext[0].type),
+                         'const int [const 20]')
+        self.assertEqual(generator.visit(ast.ext[0].type.type),
+                         'const int')
 
     def test_ptr_decl(self):
         src = 'const int ** const  x;'
         self._assert_ctoc_correct(src)
         ast = parse_to_ast(src)
         generator = c_generator.CGenerator()
-        self.assertEqual(generator.visit(ast.ext[0].type),'const int ** const')
-        self.assertEqual(generator.visit(ast.ext[0].type.type),'const int *')
-        self.assertEqual(generator.visit(ast.ext[0].type.type.type),'const int')
+        self.assertEqual(generator.visit(ast.ext[0].type),
+                         'const int ** const')
+        self.assertEqual(generator.visit(ast.ext[0].type.type),
+                         'const int *')
+        self.assertEqual(generator.visit(ast.ext[0].type.type.type),
+                         'const int')
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_c_generator.py
+++ b/tests/test_c_generator.py
@@ -336,8 +336,17 @@ class TestCtoC(unittest.TestCase):
         self._assert_ctoc_correct('int g(const int a[const 20]){}')
         ast = parse_to_ast('const int a[const 20];')
         generator = c_generator.CGenerator()
-        self.assertEqual(generator.visit(ast.ext[0].type), 'const int[const 20]')
+        self.assertEqual(generator.visit(ast.ext[0].type), 'const int [const 20]')
         self.assertEqual(generator.visit(ast.ext[0].type.type), 'const int')
+
+    def test_ptr_decl(self):
+        src = 'const int ** const  x;'
+        self._assert_ctoc_correct(src)
+        ast = parse_to_ast(src)
+        generator = c_generator.CGenerator()
+        self.assertEqual(generator.visit(ast.ext[0].type),'const int ** const')
+        self.assertEqual(generator.visit(ast.ext[0].type.type),'const int *')
+        self.assertEqual(generator.visit(ast.ext[0].type.type.type),'const int')
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
I just realized a few things:

- Pointer types are not generated correctly.  
Example:
```python
from pycparser import c_parser, c_ast, c_generator
parser = c_parser.CParser()
gen = c_generator.CGenerator()
ast = parser.parse('const int ** const  x;')

>>> gen.visit(ast.ext[0])
'const int ** const x'
>>> gen.visit(ast.ext[0].type)
'const int'
>>> gen.visit(ast.ext[0].type.type)
'const int'
>>> gen.visit(ast.ext[0].type.type.type)
'const int'
>>> 
```

In this PR I fixed it and now it makes more sense:

```python
>>> gen.visit(ast.ext[0])
'const int ** const x'
>>> gen.visit(ast.ext[0].type)
'const int ** const'
>>> gen.visit(ast.ext[0].type.type)
'const int *'
>>> gen.visit(ast.ext[0].type.type.type)
'const int'
```

- There is code duplication between `visit_ArrayDecl`/`visit_TypeDecl` and `_generate_type`. In order to use `_generate_type`, all that is needed is to prevent it from emitting the declname when we only want to generate these decls.  
In this PR I removed this code duplication.