### PR TITLE
Fix build of lexing/parsing tables in restricted python environments

### DIFF
--- a/pycparser/_build_tables.py
+++ b/pycparser/_build_tables.py
@@ -10,13 +10,17 @@
 # License: BSD
 #-----------------------------------------------------------------
 
+# Insert '.' and '..' as first entries to the search path for modules.
+# Restricted environments like embeddable python do not include the
+# current working directory on startup.
+import sys
+sys.path[0:0] = ['.', '..']
+
 # Generate c_ast.py
 from _ast_gen import ASTCodeGenerator
 ast_gen = ASTCodeGenerator('_c_ast.cfg')
 ast_gen.generate(open('c_ast.py', 'w'))
 
-import sys
-sys.path[0:0] = ['.', '..']
 from pycparser import c_parser
 
 # Generates the tables


### PR DESCRIPTION
Restricted environments like embeddable python do not include the current working directory on startup, thus the call to `_build_tables.py` fails when invoking `setup.py`:

    D:\Repositories\pycparser.git>python-3.6.8-embed-amd64\python.exe setup.py sdist
    [...]
    making hard links in pycparser-2.19...
    Build the lexing/parsing tables
    Traceback (most recent call last):
      File "_build_tables.py", line 14, in <module>
        from _ast_gen import ASTCodeGenerator
    ModuleNotFoundError: No module named '_ast_gen'
    Traceback (most recent call last):
      File "setup.py", line 65, in <module>
        cmdclass={'install': install, 'sdist': sdist},
      File "distutils\core.py", line 148, in setup
      File "distutils\dist.py", line 955, in run_commands
      File "distutils\dist.py", line 974, in run_command
      File "distutils\command\sdist.py", line 155, in run
      File "distutils\command\sdist.py", line 435, in make_distribution
      File "setup.py", line 32, in make_release_tree
        msg="Build the lexing/parsing tables")
      File "distutils\cmd.py", line 335, in execute
      File "distutils\util.py", line 301, in execute
      File "setup.py", line 18, in _run_build_tables
        cwd=os.path.join(dir, 'pycparser'))
      File "subprocess.py", line 311, in check_call
    subprocess.CalledProcessError: Command '['D:\\Repositories\\pycparser.git\\python-3.6.8-embed-amd64\\python.exe', '-B', '_build_tables.py']' returned non-zero exit status 1.

Inserting `'.'` and `'..'` to `sys.path` before any `import` statements in `_build_tables.py` fixes this issue.