### PR TITLE
Fix issue #324: u/l constant integer suffix

### DIFF
--- a/pycparser/c_parser.py
+++ b/pycparser/c_parser.py
@@ -1766,14 +1766,26 @@ class CParser(PLYParser):
                         | INT_CONST_HEX
                         | INT_CONST_BIN
         """
-        u = ''
-        l = ''
+        uCount = 0
+        lCount = 0
         for x in p[1][-3:]:
             if x in ('l', 'L'):
-                l += 'long '
+                lCount += 1
             elif x in ('u', 'U'):
-                u = 'unsigned '
-        t = u+l+'int'
+                uCount += 1
+        t = ''
+        if uCount > 1:
+             raise GrammarError('Constant cannot have more than one u/U suffix.')
+        elif lCount > 2:
+             raise GrammarError('Constant cannot have more than two l/L suffix.')
+        else:
+            if uCount:
+                t += 'unsigned '
+            if lCount == 1:
+                t += 'long '
+            elif lCount == 2:
+                t += 'long long '
+            t += 'int'
         p[0] = c_ast.Constant(
             t, p[1], self._token_coord(p, 1))
 

--- a/pycparser/c_parser.py
+++ b/pycparser/c_parser.py
@@ -1774,10 +1774,10 @@ class CParser(PLYParser):
             elif x in ('u', 'U'):
                 uCount += 1
         t = ''
-        if uCount > 1:
-             raise GrammarError('Constant cannot have more than one u/U suffix.')
+        if uCount > 0:
+             raise ValueError('Constant cannot have more than one u/U suffix.')
         elif lCount > 2:
-             raise GrammarError('Constant cannot have more than two l/L suffix.')
+             raise ValueError('Constant cannot have more than two l/L suffix.')
         else:
             if uCount:
                 t += 'unsigned '

--- a/pycparser/c_parser.py
+++ b/pycparser/c_parser.py
@@ -1766,8 +1766,16 @@ class CParser(PLYParser):
                         | INT_CONST_HEX
                         | INT_CONST_BIN
         """
+        u = ''
+        l = ''
+        for x in p[1][-3:]:
+            if x in ('l', 'L'):
+                l += 'long '
+            elif x in ('u', 'U'):
+                u = 'unsigned '
+        t = u+l+'int'
         p[0] = c_ast.Constant(
-            'int', p[1], self._token_coord(p, 1))
+            t, p[1], self._token_coord(p, 1))
 
     def p_constant_2(self, p):
         """ constant    : FLOAT_CONST

--- a/pycparser/c_parser.py
+++ b/pycparser/c_parser.py
@@ -1774,7 +1774,7 @@ class CParser(PLYParser):
             elif x in ('u', 'U'):
                 uCount += 1
         t = ''
-        if uCount > 0:
+        if uCount > 1:
              raise ValueError('Constant cannot have more than one u/U suffix.')
         elif lCount > 2:
              raise ValueError('Constant cannot have more than two l/L suffix.')

--- a/tests/test_c_parser.py
+++ b/tests/test_c_parser.py
@@ -1463,7 +1463,7 @@ class TestCParser_fundamentals(TestCParser_base):
         self.assertIsInstance(s1_ast.ext[1].body.block_items[0], Pragma)
         self.assertEqual(s1_ast.ext[1].body.block_items[0].string, 'foo')
         self.assertEqual(s1_ast.ext[1].body.block_items[0].coord.line, 4)
-        
+
         self.assertIsInstance(s1_ast.ext[1].body.block_items[2], Pragma)
         self.assertEqual(s1_ast.ext[1].body.block_items[2].string, 'baz')
         self.assertEqual(s1_ast.ext[1].body.block_items[2].coord.line, 6)

--- a/tests/test_c_parser.py
+++ b/tests/test_c_parser.py
@@ -1262,6 +1262,22 @@ class TestCParser_fundamentals(TestCParser_base):
         self.assertEqual(self.get_decl_init(d55),
             ['Constant', 'float', '0xDE.38p0'])
 
+        d6 = 'int i = 1;'
+        self.assertEqual(self.get_decl_init(d6),
+            ['Constant', 'int', '1'])
+
+        d61 = 'long int li = 1l;'
+        self.assertEqual(self.get_decl_init(d61),
+            ['Constant', 'long int', '1l'])
+
+        d62 = 'unsigned int ui = 1u;'
+        self.assertEqual(self.get_decl_init(d62),
+            ['Constant', 'unsigned int', '1u'])
+
+        d63 = 'unsigned long long int ulli = 1LLU;'
+        self.assertEqual(self.get_decl_init(d63),
+            ['Constant', 'unsigned long long int', '1LLU'])
+
     def test_decl_named_inits(self):
         d1 = 'int a = {.k = 16};'
         self.assertEqual(self.get_decl_init(d1),


### PR DESCRIPTION
The PR fixes the issue #324.
I've followed the changes made in PR #277 