### PR TITLE
Fix issue #99: parser for FuncDecl incorrectly sets declname attribute on return type

### DIFF
--- a/pycparser/c_generator.py
+++ b/pycparser/c_generator.py
@@ -119,7 +119,7 @@ class CGenerator(object):
         return s
 
     def visit_Cast(self, n):
-        s = '(' + self._generate_type(n.to_type) + ')'
+        s = '(' + self._generate_type(n.to_type, emit_declname=False) + ')'
         return s + ' ' + self._parenthesize_unless_simple(n.expr)
 
     def visit_ExprList(self, n):
@@ -293,10 +293,10 @@ class CGenerator(object):
 
     def visit_ArrayDecl(self, n):
         return self._generate_type(n, emit_declname=False)
-        
+
     def visit_TypeDecl(self, n):
         return self._generate_type(n, emit_declname=False)
-        
+
     def visit_PtrDecl(self, n):
         return self._generate_type(n, emit_declname=False)
 
@@ -389,7 +389,7 @@ class CGenerator(object):
             #
             for i, modifier in enumerate(modifiers):
                 if isinstance(modifier, c_ast.ArrayDecl):
-                    if (i != 0 and 
+                    if (i != 0 and
                         isinstance(modifiers[i - 1], c_ast.PtrDecl)):
                             nstr = '(' + nstr + ')'
                     nstr += '['
@@ -397,13 +397,13 @@ class CGenerator(object):
                         nstr += ' '.join(modifier.dim_quals) + ' '
                     nstr += self.visit(modifier.dim) + ']'
                 elif isinstance(modifier, c_ast.FuncDecl):
-                    if (i != 0 and 
+                    if (i != 0 and
                         isinstance(modifiers[i - 1], c_ast.PtrDecl)):
                             nstr = '(' + nstr + ')'
                     nstr += '(' + self.visit(modifier.args) + ')'
                 elif isinstance(modifier, c_ast.PtrDecl):
                     if modifier.quals:
-                        nstr = '* %s%s' % (' '.join(modifier.quals), 
+                        nstr = '* %s%s' % (' '.join(modifier.quals),
                                            ' ' + nstr if nstr else '')
                     else:
                         nstr = '*' + nstr

--- a/tests/test_c_generator.py
+++ b/tests/test_c_generator.py
@@ -1,15 +1,12 @@
 import os
 import platform
 import sys
-import textwrap
 import unittest
 
 # Run from the root dir
 sys.path.insert(0, '.')
 
 from pycparser import c_parser, c_generator, c_ast, parse_file
-
-CPPPATH = 'cpp'
 
 _c_parser = c_parser.CParser(
                 lex_optimize=False,
@@ -379,14 +376,12 @@ class TestCasttoC(unittest.TestCase):
         self.assertEqual(generator.visit(c_ast.Cast(int_type, test_fun)),
                          '(int) test_fun()')
 
-    @unittest.skipUnless(platform.system() == 'Linux',
-                         'cpp only works on Linux')
     def test_to_type_with_cpp(self):
         generator = c_generator.CGenerator()
         test_fun = c_ast.FuncCall(c_ast.ID('test_fun'), c_ast.ExprList([]))
         memmgr_path = self._find_file('memmgr.h')
 
-        ast2 = parse_file(memmgr_path, use_cpp=True, cpp_path=CPPPATH)
+        ast2 = parse_file(memmgr_path, use_cpp=True)
         void_ptr_type = ast2.ext[-3].type.type
         void_type = void_ptr_type.type
         self.assertEqual(generator.visit(c_ast.Cast(void_ptr_type, test_fun)),

--- a/tests/test_c_generator.py
+++ b/tests/test_c_generator.py
@@ -358,6 +358,13 @@ class TestCtoC(unittest.TestCase):
 
 
 class TestCasttoC(unittest.TestCase):
+    def _find_file(self, name):
+        root_dir = os.path.dirname(__file__)
+        name = os.path.join(root_dir, 'c_files', name)
+        assert os.path.exists(name)
+        return name
+
+
     def test_to_type(self):
         src = 'int *x;'
         generator = c_generator.CGenerator()
@@ -371,8 +378,8 @@ class TestCasttoC(unittest.TestCase):
         self.assertEqual(generator.visit(c_ast.Cast(int_type, test_fun)),
                          '(int) test_fun()')
 
-        testdir = os.path.dirname(__file__)
-        memmgr_path = os.path.join(testdir, 'c_files', 'memmgr.h')
+        memmgr_path = self._find_file('memmgr.h')
+        print(memmgr_path)
         ast2 = parse_file(memmgr_path, use_cpp=True, cpp_path=CPPPATH)
         void_ptr_type = ast2.ext[-3].type.type
         void_type = void_ptr_type.type

--- a/tests/test_c_generator.py
+++ b/tests/test_c_generator.py
@@ -371,7 +371,8 @@ class TestCasttoC(unittest.TestCase):
         self.assertEqual(generator.visit(c_ast.Cast(int_type, test_fun)),
                          '(int) test_fun()')
 
-        memmgr_path = os.path.join('examples', 'c_files', 'memmgr.h')
+        testdir = os.path.dirname(__file__)
+        memmgr_path = os.path.join(testdir, 'c_files', 'memmgr.h')
         ast2 = parse_file(memmgr_path, use_cpp=True, cpp_path=CPPPATH)
         void_ptr_type = ast2.ext[-3].type.type
         void_type = void_ptr_type.type

--- a/tests/test_c_generator.py
+++ b/tests/test_c_generator.py
@@ -376,6 +376,8 @@ class TestCasttoC(unittest.TestCase):
         self.assertEqual(generator.visit(c_ast.Cast(int_type, test_fun)),
                          '(int) test_fun()')
 
+    @unittest.skipUnless(platform.system() == 'Linux',
+                         'cpp only works on Linux')
     def test_to_type_with_cpp(self):
         generator = c_generator.CGenerator()
         test_fun = c_ast.FuncCall(c_ast.ID('test_fun'), c_ast.ExprList([]))

--- a/tests/test_c_generator.py
+++ b/tests/test_c_generator.py
@@ -5,7 +5,7 @@ import unittest
 # Run from the root dir
 sys.path.insert(0, '.')
 
-from pycparser import c_parser, c_generator, c_ast
+from pycparser import c_parser, c_generator, c_ast, parse_file
 
 _c_parser = c_parser.CParser(
                 lex_optimize=False,
@@ -352,6 +352,29 @@ class TestCtoC(unittest.TestCase):
                          'const int *')
         self.assertEqual(generator.visit(ast.ext[0].type.type.type),
                          'const int')
+
+
+class TestCasttoC(unittest.TestCase):
+    def test_to_type(self):
+        src = 'int *x;'
+        generator = c_generator.CGenerator()
+        test_fun = c_ast.FuncCall(c_ast.ID('test_fun'), c_ast.ExprList([]))
+
+        ast1 = parse_to_ast(src)
+        int_ptr_type = ast1.ext[0].type
+        int_type = int_ptr_type.type
+        self.assertEqual(generator.visit(c_ast.Cast(int_ptr_type, test_fun)),
+                         '(int *) test_fun()')
+        self.assertEqual(generator.visit(c_ast.Cast(int_type, test_fun)),
+                         '(int) test_fun()')
+
+        ast2 = parse_file('examples/c_files/memmgr.h', use_cpp=True)
+        void_ptr_type = ast2.ext[-3].type.type
+        void_type = void_ptr_type.type
+        self.assertEqual(generator.visit(c_ast.Cast(void_ptr_type, test_fun)),
+                         '(void *) test_fun()')
+        self.assertEqual(generator.visit(c_ast.Cast(void_type, test_fun)),
+                         '(void) test_fun()')
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_c_generator.py
+++ b/tests/test_c_generator.py
@@ -1,4 +1,5 @@
 import os
+import platform
 import sys
 import textwrap
 import unittest
@@ -359,8 +360,8 @@ class TestCtoC(unittest.TestCase):
 
 class TestCasttoC(unittest.TestCase):
     def _find_file(self, name):
-        root_dir = os.path.dirname(__file__)
-        name = os.path.join(root_dir, 'c_files', name)
+        test_dir = os.path.dirname(__file__)
+        name = os.path.join(test_dir, 'c_files', name)
         assert os.path.exists(name)
         return name
 
@@ -378,8 +379,13 @@ class TestCasttoC(unittest.TestCase):
         self.assertEqual(generator.visit(c_ast.Cast(int_type, test_fun)),
                          '(int) test_fun()')
 
+    @unittest.skipUnless(platform.system() == 'Linux',
+                         'cpp only works on Linux')
+    def test_to_type_with_cpp(self):
+        generator = c_generator.CGenerator()
+        test_fun = c_ast.FuncCall(c_ast.ID('test_fun'), c_ast.ExprList([]))
         memmgr_path = self._find_file('memmgr.h')
-        print(memmgr_path)
+
         ast2 = parse_file(memmgr_path, use_cpp=True, cpp_path=CPPPATH)
         void_ptr_type = ast2.ext[-3].type.type
         void_type = void_ptr_type.type

--- a/tests/test_c_generator.py
+++ b/tests/test_c_generator.py
@@ -1,3 +1,4 @@
+import os
 import sys
 import textwrap
 import unittest
@@ -6,6 +7,8 @@ import unittest
 sys.path.insert(0, '.')
 
 from pycparser import c_parser, c_generator, c_ast, parse_file
+
+CPPPATH = 'cpp'
 
 _c_parser = c_parser.CParser(
                 lex_optimize=False,
@@ -368,7 +371,8 @@ class TestCasttoC(unittest.TestCase):
         self.assertEqual(generator.visit(c_ast.Cast(int_type, test_fun)),
                          '(int) test_fun()')
 
-        ast2 = parse_file('examples/c_files/memmgr.h', use_cpp=True)
+        memmgr_path = os.path.join('examples', 'c_files', 'memmgr.h')
+        ast2 = parse_file(memmgr_path, use_cpp=True, cpp_path=CPPPATH)
         void_ptr_type = ast2.ext[-3].type.type
         void_type = void_ptr_type.type
         self.assertEqual(generator.visit(c_ast.Cast(void_ptr_type, test_fun)),


### PR DESCRIPTION
visit_Cast was emitting declname (default behavior) for to_type attribute incorrectly.