### PR TITLE
Fix slow backtracking when checking for invalid strings

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,4 +10,6 @@ matrix:
     - python: 3.7
       dist: xenial
       sudo: true
-script: python tests/all_tests.py
+script:
+  - pip install regex
+  - python tests/all_tests.py

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -9,7 +9,7 @@ environment:
 build: off
 
 install:
-  - pip install regex
+  - "%PYTHON%\\python.exe -m pip install regex"
 
 test_script:
   - "%PYTHON%\\python.exe tests\\all_tests.py"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -8,5 +8,8 @@ environment:
 
 build: off
 
+install:
+  - pip install regex
+
 test_script:
   - "%PYTHON%\\python.exe tests\\all_tests.py"

--- a/examples/c_json.py
+++ b/examples/c_json.py
@@ -38,7 +38,7 @@ from __future__ import print_function
 
 import json
 import sys
-import re
+import regex as re
 
 # This is not required if you've installed pycparser into
 # your site-packages/ with setup.py

--- a/pycparser/c_lexer.py
+++ b/pycparser/c_lexer.py
@@ -6,7 +6,7 @@
 # Eli Bendersky [https://eli.thegreenplace.net/]
 # License: BSD
 #------------------------------------------------------------------------------
-import re
+import regex as re
 import sys
 
 from .ply import lex
@@ -221,7 +221,7 @@ class CLexer(object):
     string_char = r"""([^"\\\n]|"""+escape_sequence+')'
     string_literal = '"'+string_char+'*"'
     wstring_literal = 'L'+string_literal
-    bad_string_literal = '"'+string_char+'*?'+bad_escape+string_char+'*"'
+    bad_string_literal = '"(?>'+string_char+'*)'+bad_escape+string_char+'*"'
 
     # floating constants (K&R2: A.2.5.3)
     exponent_part = r"""([eE][-+]?[0-9]+)"""

--- a/pycparser/c_parser.py
+++ b/pycparser/c_parser.py
@@ -6,7 +6,7 @@
 # Eli Bendersky [https://eli.thegreenplace.net/]
 # License: BSD
 #------------------------------------------------------------------------------
-import re
+import regex as re
 
 from .ply import yacc
 

--- a/pycparser/ply/cpp.py
+++ b/pycparser/ply/cpp.py
@@ -83,7 +83,7 @@ def t_error(t):
     t.lexer.skip(1)
     return t
 
-import re
+import regex as re
 import copy
 import time
 import os.path

--- a/pycparser/ply/lex.py
+++ b/pycparser/ply/lex.py
@@ -34,7 +34,7 @@
 __version__    = '3.10'
 __tabversion__ = '3.10'
 
-import re
+import regex as re
 import sys
 import types
 import copy

--- a/pycparser/ply/yacc.py
+++ b/pycparser/ply/yacc.py
@@ -59,7 +59,7 @@
 # own risk!
 # ----------------------------------------------------------------------------
 
-import re
+import regex as re
 import types
 import sys
 import os.path

--- a/setup.py
+++ b/setup.py
@@ -61,6 +61,9 @@ setup(
     ],
     python_requires=">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*",
     packages=['pycparser', 'pycparser.ply'],
+    install_requires=[
+        'regex',
+    ],
     package_data={'pycparser': ['*.cfg']},
     cmdclass={'install': install, 'sdist': sdist},
 )

--- a/tests/test_c_ast.py
+++ b/tests/test_c_ast.py
@@ -1,5 +1,5 @@
 import pprint
-import re
+import regex as re
 import sys
 import unittest
 import weakref

--- a/tests/test_c_lexer.py
+++ b/tests/test_c_lexer.py
@@ -1,4 +1,4 @@
-import re
+import regex as re
 import sys
 import unittest
 
@@ -148,6 +148,13 @@ class TestCLexerNoErrors(unittest.TestCase):
             ['STRING_LITERAL'])
         self.assertTokensTypes(
             '"\123\123\123\123\123\123\123\123\123\123\123\123\123\123\123\123"',
+            ['STRING_LITERAL'])
+        # The lexer is permissive and allows decimal escapes (not just octal)
+        self.assertTokensTypes(
+            '"jx\9"',
+            ['STRING_LITERAL'])
+        self.assertTokensTypes(
+            '"fo\9999999"',
             ['STRING_LITERAL'])
 
     def test_mess(self):
@@ -433,9 +440,11 @@ class TestCLexerErrors(unittest.TestCase):
         self.assertLexerError(r"'\*'", ERR_INVALID_CCONST)
 
     def test_string_literals(self):
-        self.assertLexerError(r'"jx\9"', ERR_STRING_ESCAPE)
+        self.assertLexerError(r'"jx\`"', ERR_STRING_ESCAPE)
         self.assertLexerError(r'"hekllo\* on ix"', ERR_STRING_ESCAPE)
         self.assertLexerError(r'L"hekllo\* on ix"', ERR_STRING_ESCAPE)
+        # Should not suffer from slow backtracking
+        self.assertLexerError(r'"\123\123\123\123\123\123\123\123\123\123\123\123\123\123\123\`\123\123\123\123\123\123\123\123\123\123\123\123\123\123\123""', ERR_STRING_ESCAPE)
 
     def test_preprocessor(self):
         self.assertLexerError('#line "ka"', ERR_FILENAME_BEFORE_LINE)

--- a/tests/test_c_parser.py
+++ b/tests/test_c_parser.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 import pprint
-import re
+import regex as re
 import os, sys
 import io
 import unittest


### PR DESCRIPTION
Use `regex` instead of `re`, and use atomic grouping.
To avoid surprises, use it everywhere.

https://pypi.org/project/regex/

> This regex implementation is backwards-compatible with the standard
> ‘re’ module, but offers additional functionality.

Fixes #61

This uses atomic grouping, which avoids the unnecessary backtracking.

> `(?>...)`
>
> If the following pattern subsequently fails, then the subpattern as a
whole will fail.

Also fix a test that relied on the incorrect handling of regexes.
The implementation documentation says that pycparser intends to allow
**decimal** escapes permissively.