### PR TITLE
Fix error transforming an empty switch

### DIFF
--- a/pycparser/ast_transforms.py
+++ b/pycparser/ast_transforms.py
@@ -74,7 +74,8 @@ def fix_switch_cases(switch_node):
 
     # Goes over the children of the Compound below the Switch, adding them
     # either directly below new_compound or below the last Case as appropriate
-    for child in switch_node.stmt.block_items:
+    # (for `switch(cond) {}`, block_items would have been None)
+    for child in (switch_node.stmt.block_items or []):
         if isinstance(child, (c_ast.Case, c_ast.Default)):
             # If it's a Case/Default:
             # 1. Add it to the Compound and mark as "last case"

--- a/tests/test_c_parser.py
+++ b/tests/test_c_parser.py
@@ -1792,6 +1792,7 @@ class TestCParser_whole_code(TestCParser_base):
         switch = ps1.ext[0].body.block_items[0]
 
         block = switch.stmt.block_items
+        self.assertEqual(len(block), 4)
         assert_case_node(block[0], '10')
         self.assertEqual(len(block[0].stmts), 3)
         assert_case_node(block[1], '20')
@@ -1799,7 +1800,6 @@ class TestCParser_whole_code(TestCParser_base):
         assert_case_node(block[2], '30')
         self.assertEqual(len(block[2].stmts), 1)
         assert_default_node(block[3])
-        self.assertEqual(len(block), 4)
 
         s2 = r'''
         int foo(void) {
@@ -1820,6 +1820,7 @@ class TestCParser_whole_code(TestCParser_base):
         switch = ps2.ext[0].body.block_items[0]
 
         block = switch.stmt.block_items
+        self.assertEqual(len(block), 5)
         assert_default_node(block[0])
         self.assertEqual(len(block[0].stmts), 2)
         assert_case_node(block[1], '10')
@@ -1830,7 +1831,6 @@ class TestCParser_whole_code(TestCParser_base):
         self.assertEqual(len(block[1].stmts), 0)
         assert_case_node(block[4], '40')
         self.assertEqual(len(block[4].stmts), 1)
-        self.assertEqual(len(block), 5)
 
         s3 = r'''
         int foo(void) {
@@ -1842,8 +1842,7 @@ class TestCParser_whole_code(TestCParser_base):
         ps3 = self.parse(s3)
         switch = ps3.ext[0].body.block_items[0]
 
-        block = switch.stmt.block_items
-        self.assertEqual(block, [])
+        self.assertEqual(switch.stmt.block_items, [])
 
     def test_for_statement(self):
         s2 = r'''

--- a/tests/test_c_parser.py
+++ b/tests/test_c_parser.py
@@ -1799,6 +1799,7 @@ class TestCParser_whole_code(TestCParser_base):
         assert_case_node(block[2], '30')
         self.assertEqual(len(block[2].stmts), 1)
         assert_default_node(block[3])
+        self.assertEqual(len(block), 4)
 
         s2 = r'''
         int foo(void) {
@@ -1829,6 +1830,20 @@ class TestCParser_whole_code(TestCParser_base):
         self.assertEqual(len(block[1].stmts), 0)
         assert_case_node(block[4], '40')
         self.assertEqual(len(block[4].stmts), 1)
+        self.assertEqual(len(block), 5)
+
+        s3 = r'''
+        int foo(void) {
+            switch (myvar) {
+            }
+            return 0;
+        }
+        '''
+        ps3 = self.parse(s3)
+        switch = ps3.ext[0].body.block_items[0]
+
+        block = switch.stmt.block_items
+        self.assertEqual(block, [])
 
     def test_for_statement(self):
         s2 = r'''


### PR DESCRIPTION
The parser would throw on that line for `switch(1) {}`
because NoneType is not iterable.

Fixes #345