### PR TITLE
Add some "types" to zlib.h

### DIFF
--- a/utils/fake_libc_include/zlib.h
+++ b/utils/fake_libc_include/zlib.h
@@ -1,2 +1,21 @@
 #include "_fake_defines.h"
 #include "_fake_typedefs.h"
+
+#define uInt int
+#define uLong int
+#define Byte int
+
+/* Some FAR types */
+#define Bytef int
+#define charf int
+#define inft inf
+
+#define voidpc int
+#define voidpf int
+#define voidp int
+
+#define z_crc_t int
+#define z_size_t int
+
+#define alloc_func int
+#define free_func int

--- a/utils/fake_libc_include/zlib.h
+++ b/utils/fake_libc_include/zlib.h
@@ -4,30 +4,30 @@
 #include "_fake_defines.h"
 #include "_fake_typedefs.h"
 
-typedef int uInt
-typedef int uLong
+typedef int uInt;
+typedef int uLong;
 #if !defined(__MACTYPES__)
-typedef int Byte
+typedef int Byte;
 #endif
 
-typedef int Bytef
-typedef int charf
-typedef inf intf
+typedef int Bytef;
+typedef int charf;
+typedef int intf;
 typedef int uIntf;
 typedef int uLongf;
 
-typedef int voidpc
-typedef int voidpf
-typedef int voidp
+typedef int voidpc;
+typedef int voidpf;
+typedef int voidp;
 
 #if !defined(Z_U4) && !defined(Z_SOLO) && defined(STDC)
 #define Z_U4 int
 #endif
 
-typedef int z_crc_t
-typedef int z_size_t
+typedef int z_crc_t;
+typedef int z_size_t;
 
-typedef int alloc_func
-typedef int free_func
+typedef int alloc_func;
+typedef int free_func;
 
 #endif

--- a/utils/fake_libc_include/zlib.h
+++ b/utils/fake_libc_include/zlib.h
@@ -4,23 +4,30 @@
 #include "_fake_defines.h"
 #include "_fake_typedefs.h"
 
-#define uInt int
-#define uLong int
-#define Byte int
+typedef int uInt
+typedef int uLong
+#if !defined(__MACTYPES__)
+typedef int Byte
+#endif
 
-/* Some FAR types */
-#define Bytef int
-#define charf int
-#define intf inf
+typedef int Bytef
+typedef int charf
+typedef inf intf
+typedef int uIntf;
+typedef int uLongf;
 
-#define voidpc int
-#define voidpf int
-#define voidp int
+typedef int voidpc
+typedef int voidpf
+typedef int voidp
 
-#define z_crc_t int
-#define z_size_t int
+#if !defined(Z_U4) && !defined(Z_SOLO) && defined(STDC)
+#define Z_U4 int
+#endif
 
-#define alloc_func int
-#define free_func int
+typedef int z_crc_t
+typedef int z_size_t
+
+typedef int alloc_func
+typedef int free_func
 
 #endif

--- a/utils/fake_libc_include/zlib.h
+++ b/utils/fake_libc_include/zlib.h
@@ -1,3 +1,6 @@
+#ifndef ZLIB_H
+#define ZLIB_H
+
 #include "_fake_defines.h"
 #include "_fake_typedefs.h"
 
@@ -19,3 +22,5 @@
 
 #define alloc_func int
 #define free_func int
+
+#endif

--- a/utils/fake_libc_include/zlib.h
+++ b/utils/fake_libc_include/zlib.h
@@ -8,7 +8,7 @@
 /* Some FAR types */
 #define Bytef int
 #define charf int
-#define inft inf
+#define intf inf
 
 #define voidpc int
 #define voidpf int


### PR DESCRIPTION
Since `pycparser` includes a `zlib.h` some of the types defined by the real `zlib.h` is also required.

I'm not sure if the guarding #ifdef should be around the inclusion of the other fakes.