### PR TITLE
Adding ppc64le architecutre

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,7 @@
 language: python
+arch: 
+  - ppc64le
+  - amd64
 python:
   - "2.7"
   - "3.6"


### PR DESCRIPTION
Hi,
I had added ppc64le support and looks like its been successfully added. I believe it is ready for the final review and merge.

The travis-ci build logs can be verified from the link below.
https://www.travis-ci.com/github/kishorkunal-raj/pycparser/builds/182741818
Please have a look.

Thanks!!"