### PR TITLE
Extra line breaks when c_ast.If are chained

### DIFF
--- a/pycparser/c_generator.py
+++ b/pycparser/c_generator.py
@@ -399,6 +399,8 @@ class CGenerator(object):
             # compute its own indentation.
             #
             return self.visit(n)
+        elif typ in (c_ast.If,):
+            return indent + self.visit(n)
         else:
             return indent + self.visit(n) + '\n'
 

--- a/tests/test_c_generator.py
+++ b/tests/test_c_generator.py
@@ -423,5 +423,21 @@ class TestCasttoC(unittest.TestCase):
         self.assertEqual(generator.visit(c_ast.Cast(void_type, test_fun)),
                          '(void) test_fun()')
 
+    def test_nested_else_if_line_breaks(self):
+        generator = c_generator.CGenerator()
+        test_ast1 = c_ast.If(None, None, None)
+        test_ast2 = c_ast.If(None, None, c_ast.If(None, None, None))
+        test_ast3 = c_ast.If(None, None, c_ast.If(None, None, c_ast.If(None, None, None)))
+        test_ast4 = c_ast.If(None, c_ast.Compound([]), c_ast.If(None, c_ast.Compound([]), c_ast.If(None, c_ast.Compound([]), None)))
+
+        self.assertEqual(generator.visit(test_ast1),
+                         'if ()\n  \n')
+        self.assertEqual(generator.visit(test_ast2),
+                         'if ()\n  \nelse\n  if ()\n  \n')
+        self.assertEqual(generator.visit(test_ast3),
+                         'if ()\n  \nelse\n  if ()\n  \nelse\n  if ()\n  \n')
+        self.assertEqual(generator.visit(test_ast4),
+                         'if ()\n{\n}\nelse\n  if ()\n{\n}\nelse\n  if ()\n{\n}\n')
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
```
>>> from pycparser import c_ast, c_generator
>>> generator = c_generator.CGenerator()
>>> generator.visit(c_ast.If(None, None, c_ast.If(None, None, c_ast.If(None, None, None))))
'if ()\n  \nelse\n  if ()\n  \nelse\n  if ()\n  \n\n\n'
```

Multiple trailing line breaks appear at the end of the code (one per if statement) when no one should be there.