### PR TITLE
Introduce partial C11 support

### DIFF
--- a/pycparser/_ast_gen.py
+++ b/pycparser/_ast_gen.py
@@ -86,7 +86,7 @@ class NodeCfg(object):
         src = self._gen_init()
         src += '\n' + self._gen_children()
         src += '\n' + self._gen_iter()
-
+        src += '\n' + self._gen_eq()
         src += '\n' + self._gen_attr_names()
         return src
 
@@ -131,6 +131,22 @@ class NodeCfg(object):
             src += '        return tuple(nodelist)\n'
         else:
             src += '        return ()\n'
+
+        return src
+
+    def _gen_eq(self):
+        src  = '    def __eq__(self, o):\n'
+        src += '        if not o: return False\n'
+        src += '        if not isinstance(o, {}): return False\n'.format(self.name)
+
+        if self.all_entries:
+            for entry in self.all_entries:
+                src += '        if self.{0} != o.{0}: return False\n'.format(entry)
+
+        src += '        return True\n\n'
+
+        src += '    def __ne__(self, o):\n'
+        src += '        return not self == o\n'
 
         return src
 

--- a/pycparser/_c_ast.cfg
+++ b/pycparser/_c_ast.cfg
@@ -25,6 +25,10 @@ ArrayRef: [name*, subscript*]
 #
 Assignment: [op, lvalue*, rvalue*]
 
+Alignas: [alignment*]
+
+Atomic: [subtype*]
+
 BinaryOp: [op, left*, right*]
 
 Break: []
@@ -59,7 +63,7 @@ Continue: []
 # init: initialization value, or None
 # bitsize: bit field size, or None
 #
-Decl: [name, quals, storage, funcspec, type*, init*, bitsize*]
+Decl: [name, quals, align, storage, funcspec, type*, init*, bitsize*]
 
 DeclList: [decls**]
 
@@ -172,14 +176,14 @@ TernaryOp: [cond*, iftrue*, iffalse*]
 
 # A base type declaration
 #
-TypeDecl: [declname, quals, type*]
+TypeDecl: [declname, quals, align, type*]
 
 # A typedef declaration.
 # Very similar to Decl, but without some attributes
 #
-Typedef: [name, quals, storage, type*]
+Typedef: [name, quals, align, storage, type*]
 
-Typename: [name, quals, type*]
+Typename: [name, quals, align, type*]
 
 UnaryOp: [op, expr*]
 

--- a/pycparser/c_ast.py
+++ b/pycparser/c_ast.py
@@ -184,6 +184,17 @@ class ArrayDecl(Node):
         if self.dim is not None:
             yield self.dim
 
+    def __eq__(self, o):
+        if not o: return False
+        if not isinstance(o, ArrayDecl): return False
+        if self.type != o.type: return False
+        if self.dim != o.dim: return False
+        if self.dim_quals != o.dim_quals: return False
+        return True
+
+    def __ne__(self, o):
+        return not self == o
+
     attr_names = ('dim_quals', )
 
 class ArrayRef(Node):
@@ -204,6 +215,16 @@ class ArrayRef(Node):
             yield self.name
         if self.subscript is not None:
             yield self.subscript
+
+    def __eq__(self, o):
+        if not o: return False
+        if not isinstance(o, ArrayRef): return False
+        if self.name != o.name: return False
+        if self.subscript != o.subscript: return False
+        return True
+
+    def __ne__(self, o):
+        return not self == o
 
     attr_names = ()
 
@@ -227,7 +248,70 @@ class Assignment(Node):
         if self.rvalue is not None:
             yield self.rvalue
 
+    def __eq__(self, o):
+        if not o: return False
+        if not isinstance(o, Assignment): return False
+        if self.op != o.op: return False
+        if self.lvalue != o.lvalue: return False
+        if self.rvalue != o.rvalue: return False
+        return True
+
+    def __ne__(self, o):
+        return not self == o
+
     attr_names = ('op', )
+
+class Alignas(Node):
+    __slots__ = ('alignment', 'coord', '__weakref__')
+    def __init__(self, alignment, coord=None):
+        self.alignment = alignment
+        self.coord = coord
+
+    def children(self):
+        nodelist = []
+        if self.alignment is not None: nodelist.append(("alignment", self.alignment))
+        return tuple(nodelist)
+
+    def __iter__(self):
+        if self.alignment is not None:
+            yield self.alignment
+
+    def __eq__(self, o):
+        if not o: return False
+        if not isinstance(o, Alignas): return False
+        if self.alignment != o.alignment: return False
+        return True
+
+    def __ne__(self, o):
+        return not self == o
+
+    attr_names = ()
+
+class Atomic(Node):
+    __slots__ = ('subtype', 'coord', '__weakref__')
+    def __init__(self, subtype, coord=None):
+        self.subtype = subtype
+        self.coord = coord
+
+    def children(self):
+        nodelist = []
+        if self.subtype is not None: nodelist.append(("subtype", self.subtype))
+        return tuple(nodelist)
+
+    def __iter__(self):
+        if self.subtype is not None:
+            yield self.subtype
+
+    def __eq__(self, o):
+        if not o: return False
+        if not isinstance(o, Atomic): return False
+        if self.subtype != o.subtype: return False
+        return True
+
+    def __ne__(self, o):
+        return not self == o
+
+    attr_names = ()
 
 class BinaryOp(Node):
     __slots__ = ('op', 'left', 'right', 'coord', '__weakref__')
@@ -249,6 +333,17 @@ class BinaryOp(Node):
         if self.right is not None:
             yield self.right
 
+    def __eq__(self, o):
+        if not o: return False
+        if not isinstance(o, BinaryOp): return False
+        if self.op != o.op: return False
+        if self.left != o.left: return False
+        if self.right != o.right: return False
+        return True
+
+    def __ne__(self, o):
+        return not self == o
+
     attr_names = ('op', )
 
 class Break(Node):
@@ -262,6 +357,14 @@ class Break(Node):
     def __iter__(self):
         return
         yield
+
+    def __eq__(self, o):
+        if not o: return False
+        if not isinstance(o, Break): return False
+        return True
+
+    def __ne__(self, o):
+        return not self == o
 
     attr_names = ()
 
@@ -285,6 +388,16 @@ class Case(Node):
         for child in (self.stmts or []):
             yield child
 
+    def __eq__(self, o):
+        if not o: return False
+        if not isinstance(o, Case): return False
+        if self.expr != o.expr: return False
+        if self.stmts != o.stmts: return False
+        return True
+
+    def __ne__(self, o):
+        return not self == o
+
     attr_names = ()
 
 class Cast(Node):
@@ -306,6 +419,16 @@ class Cast(Node):
         if self.expr is not None:
             yield self.expr
 
+    def __eq__(self, o):
+        if not o: return False
+        if not isinstance(o, Cast): return False
+        if self.to_type != o.to_type: return False
+        if self.expr != o.expr: return False
+        return True
+
+    def __ne__(self, o):
+        return not self == o
+
     attr_names = ()
 
 class Compound(Node):
@@ -323,6 +446,15 @@ class Compound(Node):
     def __iter__(self):
         for child in (self.block_items or []):
             yield child
+
+    def __eq__(self, o):
+        if not o: return False
+        if not isinstance(o, Compound): return False
+        if self.block_items != o.block_items: return False
+        return True
+
+    def __ne__(self, o):
+        return not self == o
 
     attr_names = ()
 
@@ -345,6 +477,16 @@ class CompoundLiteral(Node):
         if self.init is not None:
             yield self.init
 
+    def __eq__(self, o):
+        if not o: return False
+        if not isinstance(o, CompoundLiteral): return False
+        if self.type != o.type: return False
+        if self.init != o.init: return False
+        return True
+
+    def __ne__(self, o):
+        return not self == o
+
     attr_names = ()
 
 class Constant(Node):
@@ -362,6 +504,16 @@ class Constant(Node):
         return
         yield
 
+    def __eq__(self, o):
+        if not o: return False
+        if not isinstance(o, Constant): return False
+        if self.type != o.type: return False
+        if self.value != o.value: return False
+        return True
+
+    def __ne__(self, o):
+        return not self == o
+
     attr_names = ('type', 'value', )
 
 class Continue(Node):
@@ -376,13 +528,22 @@ class Continue(Node):
         return
         yield
 
+    def __eq__(self, o):
+        if not o: return False
+        if not isinstance(o, Continue): return False
+        return True
+
+    def __ne__(self, o):
+        return not self == o
+
     attr_names = ()
 
 class Decl(Node):
-    __slots__ = ('name', 'quals', 'storage', 'funcspec', 'type', 'init', 'bitsize', 'coord', '__weakref__')
-    def __init__(self, name, quals, storage, funcspec, type, init, bitsize, coord=None):
+    __slots__ = ('name', 'quals', 'align', 'storage', 'funcspec', 'type', 'init', 'bitsize', 'coord', '__weakref__')
+    def __init__(self, name, quals, align, storage, funcspec, type, init, bitsize, coord=None):
         self.name = name
         self.quals = quals
+        self.align = align
         self.storage = storage
         self.funcspec = funcspec
         self.type = type
@@ -405,7 +566,23 @@ class Decl(Node):
         if self.bitsize is not None:
             yield self.bitsize
 
-    attr_names = ('name', 'quals', 'storage', 'funcspec', )
+    def __eq__(self, o):
+        if not o: return False
+        if not isinstance(o, Decl): return False
+        if self.name != o.name: return False
+        if self.quals != o.quals: return False
+        if self.align != o.align: return False
+        if self.storage != o.storage: return False
+        if self.funcspec != o.funcspec: return False
+        if self.type != o.type: return False
+        if self.init != o.init: return False
+        if self.bitsize != o.bitsize: return False
+        return True
+
+    def __ne__(self, o):
+        return not self == o
+
+    attr_names = ('name', 'quals', 'align', 'storage', 'funcspec', )
 
 class DeclList(Node):
     __slots__ = ('decls', 'coord', '__weakref__')
@@ -422,6 +599,15 @@ class DeclList(Node):
     def __iter__(self):
         for child in (self.decls or []):
             yield child
+
+    def __eq__(self, o):
+        if not o: return False
+        if not isinstance(o, DeclList): return False
+        if self.decls != o.decls: return False
+        return True
+
+    def __ne__(self, o):
+        return not self == o
 
     attr_names = ()
 
@@ -440,6 +626,15 @@ class Default(Node):
     def __iter__(self):
         for child in (self.stmts or []):
             yield child
+
+    def __eq__(self, o):
+        if not o: return False
+        if not isinstance(o, Default): return False
+        if self.stmts != o.stmts: return False
+        return True
+
+    def __ne__(self, o):
+        return not self == o
 
     attr_names = ()
 
@@ -462,6 +657,16 @@ class DoWhile(Node):
         if self.stmt is not None:
             yield self.stmt
 
+    def __eq__(self, o):
+        if not o: return False
+        if not isinstance(o, DoWhile): return False
+        if self.cond != o.cond: return False
+        if self.stmt != o.stmt: return False
+        return True
+
+    def __ne__(self, o):
+        return not self == o
+
     attr_names = ()
 
 class EllipsisParam(Node):
@@ -476,6 +681,14 @@ class EllipsisParam(Node):
         return
         yield
 
+    def __eq__(self, o):
+        if not o: return False
+        if not isinstance(o, EllipsisParam): return False
+        return True
+
+    def __ne__(self, o):
+        return not self == o
+
     attr_names = ()
 
 class EmptyStatement(Node):
@@ -489,6 +702,14 @@ class EmptyStatement(Node):
     def __iter__(self):
         return
         yield
+
+    def __eq__(self, o):
+        if not o: return False
+        if not isinstance(o, EmptyStatement): return False
+        return True
+
+    def __ne__(self, o):
+        return not self == o
 
     attr_names = ()
 
@@ -508,6 +729,16 @@ class Enum(Node):
         if self.values is not None:
             yield self.values
 
+    def __eq__(self, o):
+        if not o: return False
+        if not isinstance(o, Enum): return False
+        if self.name != o.name: return False
+        if self.values != o.values: return False
+        return True
+
+    def __ne__(self, o):
+        return not self == o
+
     attr_names = ('name', )
 
 class Enumerator(Node):
@@ -525,6 +756,16 @@ class Enumerator(Node):
     def __iter__(self):
         if self.value is not None:
             yield self.value
+
+    def __eq__(self, o):
+        if not o: return False
+        if not isinstance(o, Enumerator): return False
+        if self.name != o.name: return False
+        if self.value != o.value: return False
+        return True
+
+    def __ne__(self, o):
+        return not self == o
 
     attr_names = ('name', )
 
@@ -544,6 +785,15 @@ class EnumeratorList(Node):
         for child in (self.enumerators or []):
             yield child
 
+    def __eq__(self, o):
+        if not o: return False
+        if not isinstance(o, EnumeratorList): return False
+        if self.enumerators != o.enumerators: return False
+        return True
+
+    def __ne__(self, o):
+        return not self == o
+
     attr_names = ()
 
 class ExprList(Node):
@@ -562,6 +812,15 @@ class ExprList(Node):
         for child in (self.exprs or []):
             yield child
 
+    def __eq__(self, o):
+        if not o: return False
+        if not isinstance(o, ExprList): return False
+        if self.exprs != o.exprs: return False
+        return True
+
+    def __ne__(self, o):
+        return not self == o
+
     attr_names = ()
 
 class FileAST(Node):
@@ -579,6 +838,15 @@ class FileAST(Node):
     def __iter__(self):
         for child in (self.ext or []):
             yield child
+
+    def __eq__(self, o):
+        if not o: return False
+        if not isinstance(o, FileAST): return False
+        if self.ext != o.ext: return False
+        return True
+
+    def __ne__(self, o):
+        return not self == o
 
     attr_names = ()
 
@@ -609,6 +877,18 @@ class For(Node):
         if self.stmt is not None:
             yield self.stmt
 
+    def __eq__(self, o):
+        if not o: return False
+        if not isinstance(o, For): return False
+        if self.init != o.init: return False
+        if self.cond != o.cond: return False
+        if self.next != o.next: return False
+        if self.stmt != o.stmt: return False
+        return True
+
+    def __ne__(self, o):
+        return not self == o
+
     attr_names = ()
 
 class FuncCall(Node):
@@ -630,6 +910,16 @@ class FuncCall(Node):
         if self.args is not None:
             yield self.args
 
+    def __eq__(self, o):
+        if not o: return False
+        if not isinstance(o, FuncCall): return False
+        if self.name != o.name: return False
+        if self.args != o.args: return False
+        return True
+
+    def __ne__(self, o):
+        return not self == o
+
     attr_names = ()
 
 class FuncDecl(Node):
@@ -650,6 +940,16 @@ class FuncDecl(Node):
             yield self.args
         if self.type is not None:
             yield self.type
+
+    def __eq__(self, o):
+        if not o: return False
+        if not isinstance(o, FuncDecl): return False
+        if self.args != o.args: return False
+        if self.type != o.type: return False
+        return True
+
+    def __ne__(self, o):
+        return not self == o
 
     attr_names = ()
 
@@ -677,6 +977,17 @@ class FuncDef(Node):
         for child in (self.param_decls or []):
             yield child
 
+    def __eq__(self, o):
+        if not o: return False
+        if not isinstance(o, FuncDef): return False
+        if self.decl != o.decl: return False
+        if self.param_decls != o.param_decls: return False
+        if self.body != o.body: return False
+        return True
+
+    def __ne__(self, o):
+        return not self == o
+
     attr_names = ()
 
 class Goto(Node):
@@ -692,6 +1003,15 @@ class Goto(Node):
     def __iter__(self):
         return
         yield
+
+    def __eq__(self, o):
+        if not o: return False
+        if not isinstance(o, Goto): return False
+        if self.name != o.name: return False
+        return True
+
+    def __ne__(self, o):
+        return not self == o
 
     attr_names = ('name', )
 
@@ -709,6 +1029,15 @@ class ID(Node):
         return
         yield
 
+    def __eq__(self, o):
+        if not o: return False
+        if not isinstance(o, ID): return False
+        if self.name != o.name: return False
+        return True
+
+    def __ne__(self, o):
+        return not self == o
+
     attr_names = ('name', )
 
 class IdentifierType(Node):
@@ -724,6 +1053,15 @@ class IdentifierType(Node):
     def __iter__(self):
         return
         yield
+
+    def __eq__(self, o):
+        if not o: return False
+        if not isinstance(o, IdentifierType): return False
+        if self.names != o.names: return False
+        return True
+
+    def __ne__(self, o):
+        return not self == o
 
     attr_names = ('names', )
 
@@ -750,6 +1088,17 @@ class If(Node):
         if self.iffalse is not None:
             yield self.iffalse
 
+    def __eq__(self, o):
+        if not o: return False
+        if not isinstance(o, If): return False
+        if self.cond != o.cond: return False
+        if self.iftrue != o.iftrue: return False
+        if self.iffalse != o.iffalse: return False
+        return True
+
+    def __ne__(self, o):
+        return not self == o
+
     attr_names = ()
 
 class InitList(Node):
@@ -768,6 +1117,15 @@ class InitList(Node):
         for child in (self.exprs or []):
             yield child
 
+    def __eq__(self, o):
+        if not o: return False
+        if not isinstance(o, InitList): return False
+        if self.exprs != o.exprs: return False
+        return True
+
+    def __ne__(self, o):
+        return not self == o
+
     attr_names = ()
 
 class Label(Node):
@@ -785,6 +1143,16 @@ class Label(Node):
     def __iter__(self):
         if self.stmt is not None:
             yield self.stmt
+
+    def __eq__(self, o):
+        if not o: return False
+        if not isinstance(o, Label): return False
+        if self.name != o.name: return False
+        if self.stmt != o.stmt: return False
+        return True
+
+    def __ne__(self, o):
+        return not self == o
 
     attr_names = ('name', )
 
@@ -808,6 +1176,16 @@ class NamedInitializer(Node):
         for child in (self.name or []):
             yield child
 
+    def __eq__(self, o):
+        if not o: return False
+        if not isinstance(o, NamedInitializer): return False
+        if self.name != o.name: return False
+        if self.expr != o.expr: return False
+        return True
+
+    def __ne__(self, o):
+        return not self == o
+
     attr_names = ()
 
 class ParamList(Node):
@@ -825,6 +1203,15 @@ class ParamList(Node):
     def __iter__(self):
         for child in (self.params or []):
             yield child
+
+    def __eq__(self, o):
+        if not o: return False
+        if not isinstance(o, ParamList): return False
+        if self.params != o.params: return False
+        return True
+
+    def __ne__(self, o):
+        return not self == o
 
     attr_names = ()
 
@@ -844,6 +1231,16 @@ class PtrDecl(Node):
         if self.type is not None:
             yield self.type
 
+    def __eq__(self, o):
+        if not o: return False
+        if not isinstance(o, PtrDecl): return False
+        if self.quals != o.quals: return False
+        if self.type != o.type: return False
+        return True
+
+    def __ne__(self, o):
+        return not self == o
+
     attr_names = ('quals', )
 
 class Return(Node):
@@ -860,6 +1257,46 @@ class Return(Node):
     def __iter__(self):
         if self.expr is not None:
             yield self.expr
+
+    def __eq__(self, o):
+        if not o: return False
+        if not isinstance(o, Return): return False
+        if self.expr != o.expr: return False
+        return True
+
+    def __ne__(self, o):
+        return not self == o
+
+    attr_names = ()
+
+class StaticAssert(Node):
+    __slots__ = ('cond', 'message', 'coord', '__weakref__')
+    def __init__(self, cond, message, coord=None):
+        self.cond = cond
+        self.message = message
+        self.coord = coord
+
+    def children(self):
+        nodelist = []
+        if self.cond is not None: nodelist.append(("cond", self.cond))
+        if self.message is not None: nodelist.append(("message", self.message))
+        return tuple(nodelist)
+
+    def __iter__(self):
+        if self.cond is not None:
+            yield self.cond
+        if self.message is not None:
+            yield self.message
+
+    def __eq__(self, o):
+        if not o: return False
+        if not isinstance(o, StaticAssert): return False
+        if self.cond != o.cond: return False
+        if self.message != o.message: return False
+        return True
+
+    def __ne__(self, o):
+        return not self == o
 
     attr_names = ()
 
@@ -901,6 +1338,16 @@ class Struct(Node):
         for child in (self.decls or []):
             yield child
 
+    def __eq__(self, o):
+        if not o: return False
+        if not isinstance(o, Struct): return False
+        if self.name != o.name: return False
+        if self.decls != o.decls: return False
+        return True
+
+    def __ne__(self, o):
+        return not self == o
+
     attr_names = ('name', )
 
 class StructRef(Node):
@@ -923,6 +1370,17 @@ class StructRef(Node):
         if self.field is not None:
             yield self.field
 
+    def __eq__(self, o):
+        if not o: return False
+        if not isinstance(o, StructRef): return False
+        if self.name != o.name: return False
+        if self.type != o.type: return False
+        if self.field != o.field: return False
+        return True
+
+    def __ne__(self, o):
+        return not self == o
+
     attr_names = ('type', )
 
 class Switch(Node):
@@ -943,6 +1401,16 @@ class Switch(Node):
             yield self.cond
         if self.stmt is not None:
             yield self.stmt
+
+    def __eq__(self, o):
+        if not o: return False
+        if not isinstance(o, Switch): return False
+        if self.cond != o.cond: return False
+        if self.stmt != o.stmt: return False
+        return True
+
+    def __ne__(self, o):
+        return not self == o
 
     attr_names = ()
 
@@ -969,13 +1437,25 @@ class TernaryOp(Node):
         if self.iffalse is not None:
             yield self.iffalse
 
+    def __eq__(self, o):
+        if not o: return False
+        if not isinstance(o, TernaryOp): return False
+        if self.cond != o.cond: return False
+        if self.iftrue != o.iftrue: return False
+        if self.iffalse != o.iffalse: return False
+        return True
+
+    def __ne__(self, o):
+        return not self == o
+
     attr_names = ()
 
 class TypeDecl(Node):
-    __slots__ = ('declname', 'quals', 'type', 'coord', '__weakref__')
-    def __init__(self, declname, quals, type, coord=None):
+    __slots__ = ('declname', 'quals', 'align', 'type', 'coord', '__weakref__')
+    def __init__(self, declname, quals, align, type, coord=None):
         self.declname = declname
         self.quals = quals
+        self.align = align
         self.type = type
         self.coord = coord
 
@@ -988,13 +1468,26 @@ class TypeDecl(Node):
         if self.type is not None:
             yield self.type
 
-    attr_names = ('declname', 'quals', )
+    def __eq__(self, o):
+        if not o: return False
+        if not isinstance(o, TypeDecl): return False
+        if self.declname != o.declname: return False
+        if self.quals != o.quals: return False
+        if self.align != o.align: return False
+        if self.type != o.type: return False
+        return True
+
+    def __ne__(self, o):
+        return not self == o
+
+    attr_names = ('declname', 'quals', 'align', )
 
 class Typedef(Node):
-    __slots__ = ('name', 'quals', 'storage', 'type', 'coord', '__weakref__')
-    def __init__(self, name, quals, storage, type, coord=None):
+    __slots__ = ('name', 'quals', 'align', 'storage', 'type', 'coord', '__weakref__')
+    def __init__(self, name, quals, align, storage, type, coord=None):
         self.name = name
         self.quals = quals
+        self.align = align
         self.storage = storage
         self.type = type
         self.coord = coord
@@ -1008,13 +1501,27 @@ class Typedef(Node):
         if self.type is not None:
             yield self.type
 
-    attr_names = ('name', 'quals', 'storage', )
+    def __eq__(self, o):
+        if not o: return False
+        if not isinstance(o, Typedef): return False
+        if self.name != o.name: return False
+        if self.quals != o.quals: return False
+        if self.align != o.align: return False
+        if self.storage != o.storage: return False
+        if self.type != o.type: return False
+        return True
+
+    def __ne__(self, o):
+        return not self == o
+
+    attr_names = ('name', 'quals', 'align', 'storage', )
 
 class Typename(Node):
-    __slots__ = ('name', 'quals', 'type', 'coord', '__weakref__')
-    def __init__(self, name, quals, type, coord=None):
+    __slots__ = ('name', 'quals', 'align', 'type', 'coord', '__weakref__')
+    def __init__(self, name, quals, align, type, coord=None):
         self.name = name
         self.quals = quals
+        self.align = align
         self.type = type
         self.coord = coord
 
@@ -1027,7 +1534,19 @@ class Typename(Node):
         if self.type is not None:
             yield self.type
 
-    attr_names = ('name', 'quals', )
+    def __eq__(self, o):
+        if not o: return False
+        if not isinstance(o, Typename): return False
+        if self.name != o.name: return False
+        if self.quals != o.quals: return False
+        if self.align != o.align: return False
+        if self.type != o.type: return False
+        return True
+
+    def __ne__(self, o):
+        return not self == o
+
+    attr_names = ('name', 'quals', 'align', )
 
 class UnaryOp(Node):
     __slots__ = ('op', 'expr', 'coord', '__weakref__')
@@ -1044,6 +1563,16 @@ class UnaryOp(Node):
     def __iter__(self):
         if self.expr is not None:
             yield self.expr
+
+    def __eq__(self, o):
+        if not o: return False
+        if not isinstance(o, UnaryOp): return False
+        if self.op != o.op: return False
+        if self.expr != o.expr: return False
+        return True
+
+    def __ne__(self, o):
+        return not self == o
 
     attr_names = ('op', )
 
@@ -1063,6 +1592,16 @@ class Union(Node):
     def __iter__(self):
         for child in (self.decls or []):
             yield child
+
+    def __eq__(self, o):
+        if not o: return False
+        if not isinstance(o, Union): return False
+        if self.name != o.name: return False
+        if self.decls != o.decls: return False
+        return True
+
+    def __ne__(self, o):
+        return not self == o
 
     attr_names = ('name', )
 
@@ -1085,6 +1624,16 @@ class While(Node):
         if self.stmt is not None:
             yield self.stmt
 
+    def __eq__(self, o):
+        if not o: return False
+        if not isinstance(o, While): return False
+        if self.cond != o.cond: return False
+        if self.stmt != o.stmt: return False
+        return True
+
+    def __ne__(self, o):
+        return not self == o
+
     attr_names = ()
 
 class Pragma(Node):
@@ -1100,6 +1649,15 @@ class Pragma(Node):
     def __iter__(self):
         return
         yield
+
+    def __eq__(self, o):
+        if not o: return False
+        if not isinstance(o, Pragma): return False
+        if self.string != o.string: return False
+        return True
+
+    def __ne__(self, o):
+        return not self == o
 
     attr_names = ('string', )
 

--- a/pycparser/c_generator.py
+++ b/pycparser/c_generator.py
@@ -180,6 +180,12 @@ class CGenerator(object):
     def visit_Enum(self, n):
         return self._generate_struct_union_enum(n, name='enum')
 
+    def visit_Alignas(self, n):
+        return '_Alignas({})'.format(self.visit(n.alignment))
+
+    def visit_Atomic(self, n):
+        return '_Atomic({})'.format(self.visit(n.subtype))
+
     def visit_Enumerator(self, n):
         if not n.value:
             return '{indent}{name},\n'.format(
@@ -418,6 +424,7 @@ class CGenerator(object):
         s = ''
         if n.funcspec: s = ' '.join(n.funcspec) + ' '
         if n.storage: s += ' '.join(n.storage) + ' '
+        if n.align: s += self.visit(n.align[0]) + ' '
         s += self._generate_type(n.type)
         return s
 

--- a/pycparser/c_lexer.py
+++ b/pycparser/c_lexer.py
@@ -111,13 +111,14 @@ class CLexer(object):
 
     keywords_new = (
         '_BOOL', '_COMPLEX',
-        '_NORETURN', '_THREAD_LOCAL', '_STATIC_ASSERT'
+        '_NORETURN', '_THREAD_LOCAL', '_STATIC_ASSERT',
+        '_ATOMIC', '_ALIGNOF', '_ALIGNAS',
         )
 
     keyword_map = {}
 
     for keyword in keywords:
-            keyword_map[keyword.lower()] = keyword
+        keyword_map[keyword.lower()] = keyword
 
     for keyword in keywords_new:
         keyword_map[keyword[:2].upper() + keyword[2:].lower()] = keyword

--- a/pycparser/c_parser.py
+++ b/pycparser/c_parser.py
@@ -310,6 +310,11 @@ class CParser(PLYParser):
         decl.name = type.declname
         type.quals = decl.quals
 
+        for tn in typename:
+            if isinstance(tn, c_ast.Alignas):
+                type.align = tn
+                typename.remove(tn)
+
         # The typename is a list of types. If any type in this
         # list isn't an IdentifierType, it must be the only
         # type in the list (it's illegal to declare "int enum ..")
@@ -350,6 +355,7 @@ class CParser(PLYParser):
             * storage: a list of storage type qualifiers
             * type: a list of type specifiers
             * function: a list of function specifiers
+            * alignment: a list of alignment specifiers
 
             This method is given a declaration specifier, and a
             new specifier of a given kind.
@@ -358,7 +364,7 @@ class CParser(PLYParser):
             Returns the declaration specifier, with the new
             specifier incorporated.
         """
-        spec = declspec or dict(qual=[], storage=[], type=[], function=[])
+        spec = declspec or dict(qual=[], storage=[], type=[], function=[], alignment=[])
 
         if append:
             spec[kind].append(newspec)
@@ -401,6 +407,7 @@ class CParser(PLYParser):
                 declname=spec['type'][-1].names[0],
                 type=None,
                 quals=None,
+                align=spec['alignment'],
                 coord=spec['type'][-1].coord)
             # Remove the "new" type's name from the end of spec['type']
             del spec['type'][-1]
@@ -423,6 +430,7 @@ class CParser(PLYParser):
                 declaration = c_ast.Typedef(
                     name=None,
                     quals=spec['qual'],
+                    align=spec['alignment'],
                     storage=spec['storage'],
                     type=decl['decl'],
                     coord=decl['decl'].coord)
@@ -430,6 +438,7 @@ class CParser(PLYParser):
                 declaration = c_ast.Decl(
                     name=None,
                     quals=spec['qual'],
+                    align=spec['alignment'],
                     storage=spec['storage'],
                     funcspec=spec['function'],
                     type=decl['decl'],
@@ -587,6 +596,7 @@ class CParser(PLYParser):
         # no declaration specifiers - 'int' becomes the default type
         spec = dict(
             qual=[],
+            alignment=[],
             storage=[],
             type=[c_ast.IdentifierType(['int'],
                                        coord=self._token_coord(p, 1))],
@@ -707,6 +717,7 @@ class CParser(PLYParser):
                 decls = [c_ast.Decl(
                     name=None,
                     quals=spec['qual'],
+                    align=spec['alignment'],
                     storage=spec['storage'],
                     funcspec=spec['function'],
                     type=ty[0],
@@ -783,6 +794,17 @@ class CParser(PLYParser):
         """
         p[0] = self._add_declaration_specifier(p[2], p[1], 'function')
 
+    # This is a bit ugly, but we need to process atomic specifier before qualifiers,
+    # since _Atomic(int) has a conflict with _Atomic int.
+    def p_declaration_specifiers_no_type_4(self, p):
+        """ declaration_specifiers_no_type  : atomic_specifier declaration_specifiers_no_type_opt
+        """
+        p[0] = self._add_declaration_specifier(p[2], p[1], 'type')
+
+    def p_declaration_specifiers_no_type_5(self, p):
+        """ declaration_specifiers_no_type  : alignment_specifier declaration_specifiers_no_type_opt
+        """
+        p[0] = self._add_declaration_specifier(p[2], p[1], 'alignment')
 
     def p_declaration_specifiers_1(self, p):
         """ declaration_specifiers  : declaration_specifiers type_qualifier
@@ -814,6 +836,10 @@ class CParser(PLYParser):
         """
         p[0] = self._add_declaration_specifier(p[1], p[2], 'type', append=True)
 
+    def p_declaration_specifiers_7(self, p):
+        """ declaration_specifiers  : declaration_specifiers alignment_specifier
+        """
+        p[0] = self._add_declaration_specifier(p[1], p[2], 'alignment', append=True)
 
     def p_storage_class_specifier(self, p):
         """ storage_class_specifier : AUTO
@@ -852,6 +878,7 @@ class CParser(PLYParser):
                             | enum_specifier
                             | struct_or_union_specifier
                             | type_specifier_no_typeid
+                            | atomic_specifier
         """
         p[0] = p[1]
 
@@ -859,6 +886,7 @@ class CParser(PLYParser):
         """ type_qualifier  : CONST
                             | RESTRICT
                             | VOLATILE
+                            | _ATOMIC
         """
         p[0] = p[1]
 
@@ -909,8 +937,19 @@ class CParser(PLYParser):
     def p_specifier_qualifier_list_4(self, p):
         """ specifier_qualifier_list  : type_qualifier_list type_specifier
         """
-        spec = dict(qual=p[1], storage=[], type=[], function=[])
+        spec = dict(qual=p[1], alignment=[], storage=[], type=[], function=[])
         p[0] = self._add_declaration_specifier(spec, p[2], 'type', append=True)
+
+    def p_specifier_qualifier_list_5(self, p):
+        """ specifier_qualifier_list  : alignment_specifier
+        """
+        spec = dict(qual=[], alignment=[], storage=[], type=[], function=[])
+        p[0] = self._add_declaration_specifier(spec, p[1], 'alignment')
+
+    def p_specifier_qualifier_list_6(self, p):
+        """ specifier_qualifier_list  : specifier_qualifier_list alignment_specifier
+        """
+        p[0] = self._add_declaration_specifier(p[1], p[2], 'alignment')
 
     # TYPEID is allowed here (and in other struct/enum related tag names), because
     # struct/enum tags reside in their own namespace and can be named the same as types
@@ -1049,7 +1088,7 @@ class CParser(PLYParser):
         if len(p) > 3:
             p[0] = {'decl': p[1], 'bitsize': p[3]}
         else:
-            p[0] = {'decl': c_ast.TypeDecl(None, None, None), 'bitsize': p[2]}
+            p[0] = {'decl': c_ast.TypeDecl(None, None, None, None), 'bitsize': p[2]}
 
     def p_enum_specifier_1(self, p):
         """ enum_specifier  : ENUM ID
@@ -1080,6 +1119,17 @@ class CParser(PLYParser):
         else:
             p[1].enumerators.append(p[3])
             p[0] = p[1]
+
+    def p_alignment_specifier(self, p):
+        """ alignment_specifier  : _ALIGNAS LPAREN type_name RPAREN
+                                 | _ALIGNAS LPAREN constant_expression RPAREN
+        """
+        p[0] = c_ast.Alignas(p[3], self._token_coord(p, 1))
+
+    def p_atomic_specifier(self, p):
+        """ atomic_specifier  : _ATOMIC LPAREN type_name RPAREN
+        """
+        p[0] = c_ast.Atomic(p[3], self._token_coord(p, 1))
 
     def p_enumerator(self, p):
         """ enumerator  : ID
@@ -1123,6 +1173,7 @@ class CParser(PLYParser):
             declname=p[1],
             type=None,
             quals=None,
+            align=None,
             coord=self._token_coord(p, 1))
 
     @parameterized(('id', 'ID'), ('typeid', 'TYPEID'))
@@ -1310,7 +1361,8 @@ class CParser(PLYParser):
             decl = c_ast.Typename(
                 name='',
                 quals=spec['qual'],
-                type=p[2] or c_ast.TypeDecl(None, None, None),
+                align=None,
+                type=p[2] or c_ast.TypeDecl(None, None, None, None),
                 coord=self._token_coord(p, 2))
             typename = spec['type']
             decl = self._fix_decl_name_type(decl, typename)
@@ -1379,7 +1431,8 @@ class CParser(PLYParser):
         typename = c_ast.Typename(
             name='',
             quals=p[1]['qual'],
-            type=p[2] or c_ast.TypeDecl(None, None, None),
+            align=None,
+            type=p[2] or c_ast.TypeDecl(None, None, None, None),
             coord=self._token_coord(p, 2))
 
         p[0] = self._fix_decl_name_type(typename, p[1]['type'])
@@ -1387,7 +1440,7 @@ class CParser(PLYParser):
     def p_abstract_declarator_1(self, p):
         """ abstract_declarator     : pointer
         """
-        dummytype = c_ast.TypeDecl(None, None, None)
+        dummytype = c_ast.TypeDecl(None, None, None, None)
         p[0] = self._type_modify_decl(
             decl=dummytype,
             modifier=p[1])
@@ -1427,7 +1480,7 @@ class CParser(PLYParser):
         """
         quals = (p[2] if len(p) > 4 else []) or []
         p[0] = c_ast.ArrayDecl(
-            type=c_ast.TypeDecl(None, None, None),
+            type=c_ast.TypeDecl(None, None, None, None),
             dim=p[3] if len(p) > 4 else p[2],
             dim_quals=quals,
             coord=self._token_coord(p, 1))
@@ -1447,7 +1500,7 @@ class CParser(PLYParser):
         """ direct_abstract_declarator  : LBRACKET TIMES RBRACKET
         """
         p[0] = c_ast.ArrayDecl(
-            type=c_ast.TypeDecl(None, None, None),
+            type=c_ast.TypeDecl(None, None, None, None),
             dim=c_ast.ID(p[3], self._token_coord(p, 3)),
             dim_quals=[],
             coord=self._token_coord(p, 1))
@@ -1467,7 +1520,7 @@ class CParser(PLYParser):
         """
         p[0] = c_ast.FuncDecl(
             args=p[2],
-            type=c_ast.TypeDecl(None, None, None),
+            type=c_ast.TypeDecl(None, None, None, None),
             coord=self._token_coord(p, 1))
 
     # declaration is a list, statement isn't. To make it consistent, block_item
@@ -1672,6 +1725,7 @@ class CParser(PLYParser):
     def p_unary_expression_3(self, p):
         """ unary_expression    : SIZEOF unary_expression
                                 | SIZEOF LPAREN type_name RPAREN
+                                | _ALIGNOF LPAREN type_name RPAREN
         """
         p[0] = c_ast.UnaryOp(
             p[1],

--- a/tests/c_files/c11.c
+++ b/tests/c_files/c11.c
@@ -3,10 +3,19 @@
 #include <stdnoreturn.h>
 #include <threads.h>
 #include <assert.h>
+#include <stdatomic.h>
+#include <stdalign.h>
 
 /* C11 thread locals */
 _Thread_local int flag;
 thread_local int flag2;
+_Atomic int flag3;
+_Atomic(int) flag4;
+_Atomic(_Atomic(int) *) flag5;
+atomic_bool flag6;
+_Alignas(32) int q32;
+_Alignas(long long) int qll;
+alignas(64) int qqq;
 
 static_assert(sizeof(flag) == sizeof(flag2), "Really unexpected size difference");
 
@@ -24,6 +33,10 @@ int main()
 {
   _Static_assert(sizeof(flag) == sizeof(flag2), "Unexpected size difference");
   static_assert(sizeof(flag) == sizeof(flag2), "Unexpected size difference");
+  static_assert(sizeof(flag) == sizeof(flag3), "Unexpected size difference");
+  static_assert(sizeof(flag) == sizeof(flag4), "Unexpected size difference");
+  static_assert(_Alignof(int) == sizeof(int), "Unexpected int alignment");
+  static_assert(alignof(int) == sizeof(int), "Unexpected int alignment");
 
   printf("Flag: %d\n", flag);
   printf("Flag2: %d\n", flag2);

--- a/tests/test_c_generator.py
+++ b/tests/test_c_generator.py
@@ -94,6 +94,42 @@ class TestCtoC(unittest.TestCase):
         self._assert_ctoc_correct('int test(const char* const* arg);')
         self._assert_ctoc_correct('int test(const char** const arg);')
 
+    def test_atomic_decls(self):
+        self._assert_ctoc_correct('_Atomic(int *) a;')
+        self._assert_ctoc_correct('_Atomic(int) *a;')
+        self._assert_ctoc_correct('_Atomic int *a;')
+        self._assert_ctoc_correct('auto const _Atomic(int *) a;')
+        self._assert_ctoc_correct('_Atomic(_Atomic(int) *) a;')
+        self._assert_ctoc_correct('typedef _Atomic(int) atomic_int;')
+        self._assert_ctoc_correct('typedef _Atomic(_Atomic(_Atomic(int (*)(void)) *) *) t;')
+        self._assert_ctoc_correct(r'''
+            typedef struct node_t {
+                _Atomic(void*) a;
+                _Atomic(void) *b;
+                _Atomic void *c;
+            } node;
+            ''')
+
+    def test_alignment(self):
+        self._assert_ctoc_correct('_Alignas(32) int b;')
+        self._assert_ctoc_correct('int _Alignas(32) a;')
+        self._assert_ctoc_correct('_Alignas(32) _Atomic(int) b;')
+        self._assert_ctoc_correct('_Atomic(int) _Alignas(32) b;')
+        self._assert_ctoc_correct('_Alignas(long long) int a;')
+        self._assert_ctoc_correct('int _Alignas(long long) a;')
+        self._assert_ctoc_correct(r'''
+            typedef struct node_t {
+                _Alignas(64) void* next;
+                int data;
+            } node;
+            ''')
+        self._assert_ctoc_correct(r'''
+            typedef struct node_t {
+                void _Alignas(64) * next;
+                int data;
+            } node;
+            ''')
+
     def test_ternary(self):
         self._assert_ctoc_correct('''
             int main(void)

--- a/tests/test_c_lexer.py
+++ b/tests/test_c_lexer.py
@@ -90,6 +90,7 @@ class TestCLexerNoErrors(unittest.TestCase):
 
     def test_special_names(self):
         self.assertTokensTypes('sizeof offsetof', ['SIZEOF', 'OFFSETOF'])
+        self.assertTokensTypes('_Alignas _Alignof', ['_ALIGNAS', '_ALIGNOF'])
 
     def test_floating_constants(self):
         self.assertTokensTypes('1.5f', ['FLOAT_CONST'])

--- a/tests/test_c_parser.py
+++ b/tests/test_c_parser.py
@@ -2385,6 +2385,10 @@ class TestCParser_typenames(TestCParser_base):
             '''
         self.assertRaises(ParseError, self.parse, s2)
 
+    def test_static_assert(self):
+        s = '_Static_assert(1, "surprise");'
+        s_ast = self.parse(s)
+        self.assertEqual(type(s_ast.ext[0]), StaticAssert)
 
 if __name__ == '__main__':
     #~ suite = unittest.TestLoader().loadTestsFromNames(

--- a/utils/fake_libc_include/_fake_defines.h
+++ b/utils/fake_libc_include/_fake_defines.h
@@ -236,4 +236,25 @@
 /* C11 assert.h defines */
 #define static_assert _Static_assert
 
+/* C11 stdatomic.h defines */
+#define ATOMIC_BOOL_LOCK_FREE       0
+#define ATOMIC_CHAR_LOCK_FREE       0
+#define ATOMIC_CHAR16_T_LOCK_FREE   0
+#define ATOMIC_CHAR32_T_LOCK_FREE   0
+#define ATOMIC_WCHAR_T_LOCK_FREE    0
+#define ATOMIC_SHORT_LOCK_FREE      0
+#define ATOMIC_INT_LOCK_FREE        0
+#define ATOMIC_LONG_LOCK_FREE       0
+#define ATOMIC_LLONG_LOCK_FREE      0
+#define ATOMIC_POINTER_LOCK_FREE    0
+#define ATOMIC_VAR_INIT(value) (value)
+#define ATOMIC_FLAG_INIT { 0 }
+#define kill_dependency(y) (y)
+
+/* C11 stdalign.h defines */
+#define alignas _Alignas
+#define alignof _Alignof
+#define __alignas_is_defined 1
+#define __alignof_is_defined 1
+
 #endif

--- a/utils/fake_libc_include/_fake_typedefs.h
+++ b/utils/fake_libc_include/_fake_typedefs.h
@@ -169,4 +169,52 @@ typedef struct xcb_connection_t xcb_connection_t;
 typedef uint32_t xcb_window_t;
 typedef uint32_t xcb_visualid_t;
 
+/* C11 stdatomic.h types */
+typedef _Atomic(_Bool)              atomic_bool;
+typedef _Atomic(char)               atomic_char;
+typedef _Atomic(signed char)        atomic_schar;
+typedef _Atomic(unsigned char)      atomic_uchar;
+typedef _Atomic(short)              atomic_short;
+typedef _Atomic(unsigned short)     atomic_ushort;
+typedef _Atomic(int)                atomic_int;
+typedef _Atomic(unsigned int)       atomic_uint;
+typedef _Atomic(long)               atomic_long;
+typedef _Atomic(unsigned long)      atomic_ulong;
+typedef _Atomic(long long)          atomic_llong;
+typedef _Atomic(unsigned long long) atomic_ullong;
+typedef _Atomic(uint_least16_t)     atomic_char16_t;
+typedef _Atomic(uint_least32_t)     atomic_char32_t;
+typedef _Atomic(wchar_t)            atomic_wchar_t;
+typedef _Atomic(int_least8_t)       atomic_int_least8_t;
+typedef _Atomic(uint_least8_t)      atomic_uint_least8_t;
+typedef _Atomic(int_least16_t)      atomic_int_least16_t;
+typedef _Atomic(uint_least16_t)     atomic_uint_least16_t;
+typedef _Atomic(int_least32_t)      atomic_int_least32_t;
+typedef _Atomic(uint_least32_t)     atomic_uint_least32_t;
+typedef _Atomic(int_least64_t)      atomic_int_least64_t;
+typedef _Atomic(uint_least64_t)     atomic_uint_least64_t;
+typedef _Atomic(int_fast8_t)        atomic_int_fast8_t;
+typedef _Atomic(uint_fast8_t)       atomic_uint_fast8_t;
+typedef _Atomic(int_fast16_t)       atomic_int_fast16_t;
+typedef _Atomic(uint_fast16_t)      atomic_uint_fast16_t;
+typedef _Atomic(int_fast32_t)       atomic_int_fast32_t;
+typedef _Atomic(uint_fast32_t)      atomic_uint_fast32_t;
+typedef _Atomic(int_fast64_t)       atomic_int_fast64_t;
+typedef _Atomic(uint_fast64_t)      atomic_uint_fast64_t;
+typedef _Atomic(intptr_t)           atomic_intptr_t;
+typedef _Atomic(uintptr_t)          atomic_uintptr_t;
+typedef _Atomic(size_t)             atomic_size_t;
+typedef _Atomic(ptrdiff_t)          atomic_ptrdiff_t;
+typedef _Atomic(intmax_t)           atomic_intmax_t;
+typedef _Atomic(uintmax_t)          atomic_uintmax_t;
+typedef struct atomic_flag { atomic_bool _Value; } atomic_flag;
+typedef enum memory_order {
+  memory_order_relaxed,
+  memory_order_consume,
+  memory_order_acquire,
+  memory_order_release,
+  memory_order_acq_rel,
+  memory_order_seq_cst
+} memory_order;
+
 #endif

--- a/utils/fake_libc_include/stdalign.h
+++ b/utils/fake_libc_include/stdalign.h
@@ -1,0 +1,2 @@
+#include "_fake_defines.h"
+#include "_fake_typedefs.h"

--- a/utils/fake_libc_include/stdatomic.h
+++ b/utils/fake_libc_include/stdatomic.h
@@ -1,0 +1,2 @@
+#include "_fake_defines.h"
+#include "_fake_typedefs.h"


### PR DESCRIPTION
This changeset adds basic support for `_Noreturn`, `_Thread_local`, and `_Static_assert`. It additionally updates the fake libc headers to support their macro aliases (`noreturn`, `thread_local`, and `static_assert`) and fixes preprocessor tests on macOS.

references #63
