### PR TITLE
Fix examples/func_defs_add_param.py: add missing `align` parameter

### DIFF
--- a/examples/func_defs_add_param.py
+++ b/examples/func_defs_add_param.py
@@ -25,6 +25,7 @@ class ParamAdder(c_ast.NodeVisitor):
     def visit_FuncDecl(self, node):
         ty = c_ast.TypeDecl(declname='_hidden',
                             quals=[],
+                            align=[],
                             type=c_ast.IdentifierType(['int']))
         newdecl = c_ast.Decl(
                     name='_hidden',


### PR DESCRIPTION
https://github.com/eliben/pycparser/blob/d554122e2a5702daeb68a3714826c1c7df8cbea3/pycparser/c_ast.py#L992-L994

I’m not sure if `None` is appropriate, though.