### PR TITLE
Add missing SCHAR limit defines 

### DIFF
--- a/utils/fake_libc_include/_fake_defines.h
+++ b/utils/fake_libc_include/_fake_defines.h
@@ -26,6 +26,8 @@
 #define EXIT_FAILURE 1
 #define EXIT_SUCCESS 0
 
+#define SCHAR_MIN -128
+#define SCHAR_MAX 127
 #define CHAR_MIN -128
 #define CHAR_MAX 127
 #define UCHAR_MAX 255


### PR DESCRIPTION
When I tried to use the fake libc includes I found that the limits define for `SCHAR_MAX` and `SCHAR_MIN` are missing.

This PR adds a definition for `SCHAR_MIN` as well as `SCHAR_MAX`.