### PR TITLE
Add an encoding parameter to parse_file

### DIFF
--- a/pycparser/__init__.py
+++ b/pycparser/__init__.py
@@ -49,7 +49,7 @@ def preprocess_file(filename, cpp_path='cpp', cpp_args=''):
 
 
 def parse_file(filename, use_cpp=False, cpp_path='cpp', cpp_args='',
-               parser=None):
+               parser=None, encoding=None):
     """ Parse a C file using pycparser.
 
         filename:
@@ -71,6 +71,9 @@ def parse_file(filename, use_cpp=False, cpp_path='cpp', cpp_args='',
             r'-I../utils/fake_libc_include'
             If several arguments are required, pass a list of strings.
 
+        encoding:
+            Encoding to use for the file to parse
+
         parser:
             Optional parser object to be used instead of the default CParser
 
@@ -82,7 +85,7 @@ def parse_file(filename, use_cpp=False, cpp_path='cpp', cpp_args='',
     if use_cpp:
         text = preprocess_file(filename, cpp_path, cpp_args)
     else:
-        with io.open(filename) as f:
+        with io.open(filename, encoding=encoding) as f:
             text = f.read()
 
     if parser is None:


### PR DESCRIPTION
We may need to process files written on/output by compilers on a system with a different [locale.getencoding()](https://docs.python.org/3/library/locale.html#locale.getencoding), which is the default of [open()](https://docs.python.org/3/library/functions.html#open).

This patch exposes the `encoding` optional parameter of `open` to the `parse_file` API.