### PR TITLE
Feature/add  pragma support

### DIFF
--- a/pycparser/c_lexer.py
+++ b/pycparser/c_lexer.py
@@ -112,6 +112,7 @@ class CLexer(object):
         '_BOOL', '_COMPLEX',
         '_NORETURN', '_THREAD_LOCAL', '_STATIC_ASSERT',
         '_ATOMIC', '_ALIGNOF', '_ALIGNAS',
+        '_PRAGMA',
         )
 
     keyword_map = {}

--- a/pycparser/c_parser.py
+++ b/pycparser/c_parser.py
@@ -571,6 +571,11 @@ class CParser(PLYParser):
         self._parse_error('Directives not supported yet',
                           self._token_coord(p, 1))
 
+    # This encompasses two types of C99-compatible pragmas:
+    # - The #pragma directive:
+    #       # pragma character_sequence
+    # - The _Pragma unary operator:
+    #       _Pragma ( " string_literal " )
     def p_pppragma_directive(self, p):
         """ pppragma_directive      : PPPRAGMA
                                     | PPPRAGMA PPPRAGMASTR

--- a/pycparser/c_parser.py
+++ b/pycparser/c_parser.py
@@ -574,8 +574,11 @@ class CParser(PLYParser):
     def p_pppragma_directive(self, p):
         """ pppragma_directive      : PPPRAGMA
                                     | PPPRAGMA PPPRAGMASTR
+                                    | _PRAGMA LPAREN unified_string_literal RPAREN
         """
-        if len(p) == 3:
+        if len(p) == 5:
+            p[0] = c_ast.Pragma(p[3], self._token_coord(p, 2))
+        elif len(p) == 3:
             p[0] = c_ast.Pragma(p[2], self._token_coord(p, 2))
         else:
             p[0] = c_ast.Pragma("", self._token_coord(p, 1))

--- a/tests/test_c_lexer.py
+++ b/tests/test_c_lexer.py
@@ -357,6 +357,7 @@ class TestCLexerNoErrors(unittest.TestCase):
         #pragma "string"
         #pragma somestring="some_other_string"
         #pragma id 124124 and numbers 0235495
+        _Pragma("something else")
         59
         '''
         # Check that pragmas are tokenized, including trailing string
@@ -389,9 +390,19 @@ class TestCLexerNoErrors(unittest.TestCase):
             tb = self.clex.token()
             self.assertEqual(tb.type, 'PPPRAGMASTR')
 
-        t6 = self.clex.token()
-        self.assertEqual(t6.type, 'INT_CONST_DEC')
-        self.assertEqual(t6.lineno, 12)
+        t6a = self.clex.token()
+        t6l = self.clex.token()
+        t6b = self.clex.token()
+        t6r = self.clex.token()
+        self.assertEqual(t6a.type, '_PRAGMA')
+        self.assertEqual(t6l.type, 'LPAREN')
+        self.assertEqual(t6b.type, 'STRING_LITERAL')
+        self.assertEqual(t6b.value, '"something else"')
+        self.assertEqual(t6r.type, 'RPAREN')
+
+        t7 = self.clex.token()
+        self.assertEqual(t7.type, 'INT_CONST_DEC')
+        self.assertEqual(t7.lineno, 13)
 
 
 

--- a/tests/test_c_parser.py
+++ b/tests/test_c_parser.py
@@ -1736,6 +1736,7 @@ class TestCParser_fundamentals(TestCParser_base):
             struct s {
             #pragma baz
             } s;
+            _Pragma("other \"string\"")
             '''
         s1_ast = self.parse(s1)
         self.assertIsInstance(s1_ast.ext[0], Pragma)
@@ -1757,6 +1758,10 @@ class TestCParser_fundamentals(TestCParser_base):
         self.assertIsInstance(s1_ast.ext[2].type.type.decls[0], Pragma)
         self.assertEqual(s1_ast.ext[2].type.type.decls[0].string, 'baz')
         self.assertEqual(s1_ast.ext[2].type.type.decls[0].coord.line, 13)
+
+        self.assertIsInstance(s1_ast.ext[3], Pragma)
+        self.assertEqual(s1_ast.ext[3].string.value, r'"other \"string\""')
+        self.assertEqual(s1_ast.ext[3].coord.line, 15)
 
     def test_pragmacomp_or_statement(self):
         s1 = r'''


### PR DESCRIPTION
Resolves https://github.com/eliben/pycparser/issues/485 for [_Pragma](https://gcc.gnu.org/onlinedocs/cpp/Pragmas.html) support.
After the preprocessing stage, some `_Pragma`s may remain. This at least lets us parse such code. 

I'm not certain about the `_token_coord(p, 2))` here though. Might be 3?
https://github.com/statinf-software/pycparser/blob/32b35034bf06d76af10054da8cc227b9e6dd75dd/pycparser/c_parser.py#L579-L580

(PS: I get `ModuleNotFoundError: No module named '_ast_gen'` when trying to run the tests, but I think the test additions still ran and passed.)