### PR TITLE
Hash pin ci.yml workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,9 +21,9 @@ jobs:
 
     steps:
 
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@57ded4d7d5e986d7296eab16560982c6dd7c923b # v4.6.0
       with:
         python-version: ${{ matrix.python-version }}
     - name: Test


### PR DESCRIPTION
Issue #505 

Example of success run with hash pin https://github.com/joycebrum/pycparser/actions/runs/5006562582

Hashes:

- [8e5e7e5ab8b370d6c329ec480221332ada57f0ab](https://github.com/actions/checkout/commit/8e5e7e5ab8b370d6c329ec480221332ada57f0ab)
- [57ded4d7d5e986d7296eab16560982c6dd7c923b](https://github.com/actions/setup-python/commit/57ded4d7d5e986d7296eab16560982c6dd7c923b)