### PR TITLE
Beautify Node.show() for parse tree printing 

### DIFF
--- a/pycparser/_ast_gen.py
+++ b/pycparser/_ast_gen.py
@@ -224,12 +224,15 @@ class Node(object):
         """
         pass
 
-    def show(self, buf=sys.stdout, attrnames=False, nodenames=False, showcoord=False, _my_node_name=None, indent='', islast = True):
+    def show(self, buf=sys.stdout, offset=0, attrnames=False, nodenames=False, showcoord=False, _my_node_name=None, indent='', islast = True):
         """ Pretty print the Node and all its attributes and
             children (recursively) to a buffer.
 
             buf:
                 Open IO buffer into which the Node is printed.
+
+            offset:
+                Initial offset (amount of leading spaces)
 
             attrnames:
                 True if you want to see the attribute names in
@@ -250,7 +253,7 @@ class Node(object):
                 Denotes if node is final element in its tree.
         """
         marker = "└─" if islast else "├─"
-        lead = indent + marker
+        lead = ' ' * offset + indent + marker
         
         if nodenames and _my_node_name is not None:
             buf.write(lead + self.__class__.__name__+ ' <' + _my_node_name + '>: ')
@@ -275,6 +278,7 @@ class Node(object):
         for idx, (child_name, child) in enumerate(self.children()):
             child.show(
                 buf,
+                offset=offset,
                 attrnames=attrnames,
                 nodenames=nodenames,
                 showcoord=showcoord,

--- a/pycparser/_ast_gen.py
+++ b/pycparser/_ast_gen.py
@@ -244,7 +244,7 @@ class Node(object):
                 displayed.
 
             indent:
-                Spaces and verticle lines to be displayed infront of node.
+                Spaces and vertical lines to be displayed in front of node.
 
             islast:
                 Denotes if node is final element in its tree.

--- a/pycparser/_ast_gen.py
+++ b/pycparser/_ast_gen.py
@@ -224,15 +224,12 @@ class Node(object):
         """
         pass
 
-    def show(self, buf=sys.stdout, offset=0, attrnames=False, nodenames=False, showcoord=False, _my_node_name=None):
+    def show(self, buf=sys.stdout, attrnames=False, nodenames=False, showcoord=False, _my_node_name=None, indent='', islast = True):
         """ Pretty print the Node and all its attributes and
             children (recursively) to a buffer.
 
             buf:
                 Open IO buffer into which the Node is printed.
-
-            offset:
-                Initial offset (amount of leading spaces)
 
             attrnames:
                 True if you want to see the attribute names in
@@ -245,8 +242,16 @@ class Node(object):
             showcoord:
                 Do you want the coordinates of each Node to be
                 displayed.
+
+            indent:
+                Spaces and lines to be displayed behind node.
+
+            islast:
+                Denotes if node is final element in its tree.
         """
-        lead = ' ' * offset
+        marker = "└─" if islast else "├─"
+        lead = indent + marker
+        
         if nodenames and _my_node_name is not None:
             buf.write(lead + self.__class__.__name__+ ' <' + _my_node_name + '>: ')
         else:
@@ -265,14 +270,23 @@ class Node(object):
             buf.write(' (at %s)' % self.coord)
         buf.write('\n')
 
+        indent += "  " if islast else "│ "
+        
+        lastChild = None
+        
+        children = self.children()
+        if len(children) > 0:
+            _, lastChild = children[-1]
+            
         for (child_name, child) in self.children():
             child.show(
                 buf,
-                offset=offset + 2,
                 attrnames=attrnames,
                 nodenames=nodenames,
                 showcoord=showcoord,
-                _my_node_name=child_name)
+                _my_node_name=child_name,
+                indent=indent,
+                islast=(lastChild == child))
 
 
 class NodeVisitor(object):

--- a/pycparser/_ast_gen.py
+++ b/pycparser/_ast_gen.py
@@ -225,68 +225,68 @@ class Node(object):
         pass
 
     def show(self, buf=sys.stdout, attrnames=False, nodenames=False, showcoord=False, _my_node_name=None, indent='', islast = True):
-        """ Pretty print the Node and all its attributes and
-            children (recursively) to a buffer.
-
-            buf:
-                Open IO buffer into which the Node is printed.
-
-            attrnames:
-                True if you want to see the attribute names in
-                name=value pairs. False to only see the values.
-
-            nodenames:
-                True if you want to see the actual node names
-                within their parents.
-
-            showcoord:
-                Do you want the coordinates of each Node to be
-                displayed.
-
-            indent:
-                Spaces and lines to be displayed behind node.
-
-            islast:
-                Denotes if node is final element in its tree.
-        """
-        marker = "└─" if islast else "├─"
-        lead = indent + marker
-        
-        if nodenames and _my_node_name is not None:
-            buf.write(lead + self.__class__.__name__+ ' <' + _my_node_name + '>: ')
-        else:
-            buf.write(lead + self.__class__.__name__+ ': ')
-
-        if self.attr_names:
-            if attrnames:
-                nvlist = [(n, getattr(self,n)) for n in self.attr_names]
-                attrstr = ', '.join('%s=%s' % nv for nv in nvlist)
-            else:
-                vlist = [getattr(self, n) for n in self.attr_names]
-                attrstr = ', '.join('%s' % v for v in vlist)
-            buf.write(attrstr)
-
-        if showcoord:
-            buf.write(' (at %s)' % self.coord)
-        buf.write('\n')
-
-        indent += "  " if islast else "│ "
-        
-        lastChild = None
-        
-        children = self.children()
-        if len(children) > 0:
-            _, lastChild = children[-1]
+            """ Pretty print the Node and all its attributes and
+                children (recursively) to a buffer.
+    
+                buf:
+                    Open IO buffer into which the Node is printed.
+    
+                attrnames:
+                    True if you want to see the attribute names in
+                    name=value pairs. False to only see the values.
+    
+                nodenames:
+                    True if you want to see the actual node names
+                    within their parents.
+    
+                showcoord:
+                    Do you want the coordinates of each Node to be
+                    displayed.
+    
+                indent:
+                    Spaces and lines to be displayed behind node.
+    
+                islast:
+                    Denotes if node is final element in its tree.
+            """
+            marker = "└─" if islast else "├─"
+            lead = indent + marker
             
-        for (child_name, child) in self.children():
-            child.show(
-                buf,
-                attrnames=attrnames,
-                nodenames=nodenames,
-                showcoord=showcoord,
-                _my_node_name=child_name,
-                indent=indent,
-                islast=(lastChild == child))
+            if nodenames and _my_node_name is not None:
+                buf.write(lead + self.__class__.__name__+ ' <' + _my_node_name + '>: ')
+            else:
+                buf.write(lead + self.__class__.__name__+ ': ')
+    
+            if self.attr_names:
+                if attrnames:
+                    nvlist = [(n, getattr(self,n)) for n in self.attr_names]
+                    attrstr = ', '.join('%s=%s' % nv for nv in nvlist)
+                else:
+                    vlist = [getattr(self, n) for n in self.attr_names]
+                    attrstr = ', '.join('%s' % v for v in vlist)
+                buf.write(attrstr)
+    
+            if showcoord:
+                buf.write(' (at %s)' % self.coord)
+            buf.write('\n')
+    
+            indent += "  " if islast else "│ "
+            
+            lastChild = None
+            
+            children = self.children()
+            if len(children) > 0:
+                _, lastChild = children[-1]
+                
+            for (child_name, child) in self.children():
+                child.show(
+                    buf,
+                    attrnames=attrnames,
+                    nodenames=nodenames,
+                    showcoord=showcoord,
+                    _my_node_name=child_name,
+                    indent=indent,
+                    islast=(lastChild == child))
 
 
 class NodeVisitor(object):

--- a/pycparser/_ast_gen.py
+++ b/pycparser/_ast_gen.py
@@ -225,68 +225,62 @@ class Node(object):
         pass
 
     def show(self, buf=sys.stdout, attrnames=False, nodenames=False, showcoord=False, _my_node_name=None, indent='', islast = True):
-            """ Pretty print the Node and all its attributes and
-                children (recursively) to a buffer.
-    
-                buf:
-                    Open IO buffer into which the Node is printed.
-    
-                attrnames:
-                    True if you want to see the attribute names in
-                    name=value pairs. False to only see the values.
-    
-                nodenames:
-                    True if you want to see the actual node names
-                    within their parents.
-    
-                showcoord:
-                    Do you want the coordinates of each Node to be
-                    displayed.
-    
-                indent:
-                    Spaces and lines to be displayed behind node.
-    
-                islast:
-                    Denotes if node is final element in its tree.
-            """
-            marker = "└─" if islast else "├─"
-            lead = indent + marker
-            
-            if nodenames and _my_node_name is not None:
-                buf.write(lead + self.__class__.__name__+ ' <' + _my_node_name + '>: ')
+        """ Pretty print the Node and all its attributes and
+            children (recursively) to a buffer.
+
+            buf:
+                Open IO buffer into which the Node is printed.
+
+            attrnames:
+                True if you want to see the attribute names in
+                name=value pairs. False to only see the values.
+
+            nodenames:
+                True if you want to see the actual node names
+                within their parents.
+
+            showcoord:
+                Do you want the coordinates of each Node to be
+                displayed.
+
+            indent:
+                Spaces and verticle lines to be displayed infront of node.
+
+            islast:
+                Denotes if node is final element in its tree.
+        """
+        marker = "└─" if islast else "├─"
+        lead = indent + marker
+        
+        if nodenames and _my_node_name is not None:
+            buf.write(lead + self.__class__.__name__+ ' <' + _my_node_name + '>: ')
+        else:
+            buf.write(lead + self.__class__.__name__+ ': ')
+
+        if self.attr_names:
+            if attrnames:
+                nvlist = [(n, getattr(self,n)) for n in self.attr_names]
+                attrstr = ', '.join('%s=%s' % nv for nv in nvlist)
             else:
-                buf.write(lead + self.__class__.__name__+ ': ')
-    
-            if self.attr_names:
-                if attrnames:
-                    nvlist = [(n, getattr(self,n)) for n in self.attr_names]
-                    attrstr = ', '.join('%s=%s' % nv for nv in nvlist)
-                else:
-                    vlist = [getattr(self, n) for n in self.attr_names]
-                    attrstr = ', '.join('%s' % v for v in vlist)
-                buf.write(attrstr)
-    
-            if showcoord:
-                buf.write(' (at %s)' % self.coord)
-            buf.write('\n')
-    
-            indent += "  " if islast else "│ "
-            
-            lastChild = None
-            
-            children = self.children()
-            if len(children) > 0:
-                _, lastChild = children[-1]
-                
-            for (child_name, child) in self.children():
-                child.show(
-                    buf,
-                    attrnames=attrnames,
-                    nodenames=nodenames,
-                    showcoord=showcoord,
-                    _my_node_name=child_name,
-                    indent=indent,
-                    islast=(lastChild == child))
+                vlist = [getattr(self, n) for n in self.attr_names]
+                attrstr = ', '.join('%s' % v for v in vlist)
+            buf.write(attrstr)
+
+        if showcoord:
+            buf.write(' (at %s)' % self.coord)
+        buf.write('\n')
+
+        indent += "  " if islast else "│ "
+                    
+        for idx, (child_name, child) in enumerate(self.children()):
+            child.show(
+                buf,
+                attrnames=attrnames,
+                nodenames=nodenames,
+                showcoord=showcoord,
+                _my_node_name=child_name,
+                indent=indent,
+                islast=(idx == len(self.children())-1))
 
 
 class NodeVisitor(object):

--- a/pycparser/_build_tables.py
+++ b/pycparser/_build_tables.py
@@ -20,7 +20,7 @@ sys.path[0:0] = ['.', '..']
 # Generate c_ast.py
 from _ast_gen import ASTCodeGenerator
 ast_gen = ASTCodeGenerator('_c_ast.cfg')
-ast_gen.generate(open('c_ast.py', 'w'))
+ast_gen.generate(open('c_ast.py', 'w', encoding='UTF-8')))
 
 from pycparser import c_parser
 

--- a/pycparser/c_ast.py
+++ b/pycparser/c_ast.py
@@ -55,7 +55,7 @@ class Node(object):
         """
         pass
 
-        def show(self, buf=sys.stdout, attrnames=False, nodenames=False, showcoord=False, _my_node_name=None, indent='', islast = True):
+    def show(self, buf=sys.stdout, attrnames=False, nodenames=False, showcoord=False, _my_node_name=None, indent='', islast = True):
         """ Pretty print the Node and all its attributes and
             children (recursively) to a buffer.
 

--- a/pycparser/c_ast.py
+++ b/pycparser/c_ast.py
@@ -55,15 +55,12 @@ class Node(object):
         """
         pass
 
-    def show(self, buf=sys.stdout, offset=0, attrnames=False, nodenames=False, showcoord=False, _my_node_name=None):
+        def show(self, buf=sys.stdout, attrnames=False, nodenames=False, showcoord=False, _my_node_name=None, indent='', islast = True):
         """ Pretty print the Node and all its attributes and
             children (recursively) to a buffer.
 
             buf:
                 Open IO buffer into which the Node is printed.
-
-            offset:
-                Initial offset (amount of leading spaces)
 
             attrnames:
                 True if you want to see the attribute names in
@@ -76,8 +73,16 @@ class Node(object):
             showcoord:
                 Do you want the coordinates of each Node to be
                 displayed.
+
+            indent:
+                Spaces and lines to be displayed behind node.
+
+            islast:
+                Denotes if node is final element in its tree.
         """
-        lead = ' ' * offset
+        marker = "└─" if islast else "├─"
+        lead = indent + marker
+        
         if nodenames and _my_node_name is not None:
             buf.write(lead + self.__class__.__name__+ ' <' + _my_node_name + '>: ')
         else:
@@ -96,14 +101,23 @@ class Node(object):
             buf.write(' (at %s)' % self.coord)
         buf.write('\n')
 
+        indent += "  " if islast else "│ "
+        
+        lastChild = None
+        
+        children = self.children()
+        if len(children) > 0:
+            _, lastChild = children[-1]
+            
         for (child_name, child) in self.children():
             child.show(
                 buf,
-                offset=offset + 2,
                 attrnames=attrnames,
                 nodenames=nodenames,
                 showcoord=showcoord,
-                _my_node_name=child_name)
+                _my_node_name=child_name,
+                indent=indent,
+                islast=(lastChild == child))
 
 
 class NodeVisitor(object):

--- a/pycparser/c_ast.py
+++ b/pycparser/c_ast.py
@@ -55,12 +55,15 @@ class Node(object):
         """
         pass
 
-    def show(self, buf=sys.stdout, attrnames=False, nodenames=False, showcoord=False, _my_node_name=None, indent='', islast = True):
+    def show(self, buf=sys.stdout, offset=0, attrnames=False, nodenames=False, showcoord=False, _my_node_name=None, indent='', islast = True):
         """ Pretty print the Node and all its attributes and
             children (recursively) to a buffer.
 
             buf:
                 Open IO buffer into which the Node is printed.
+
+            offset:
+                Initial offset (amount of leading spaces)
 
             attrnames:
                 True if you want to see the attribute names in
@@ -75,13 +78,13 @@ class Node(object):
                 displayed.
 
             indent:
-                Spaces and lines to be displayed behind node.
+                Spaces and vertical lines to be displayed in front of node.
 
             islast:
                 Denotes if node is final element in its tree.
         """
         marker = "└─" if islast else "├─"
-        lead = indent + marker
+        lead = ' ' * offset + indent + marker
         
         if nodenames and _my_node_name is not None:
             buf.write(lead + self.__class__.__name__+ ' <' + _my_node_name + '>: ')
@@ -102,22 +105,17 @@ class Node(object):
         buf.write('\n')
 
         indent += "  " if islast else "│ "
-        
-        lastChild = None
-        
-        children = self.children()
-        if len(children) > 0:
-            _, lastChild = children[-1]
-            
-        for (child_name, child) in self.children():
+                    
+        for idx, (child_name, child) in enumerate(self.children()):
             child.show(
                 buf,
+                offset=offset,
                 attrnames=attrnames,
                 nodenames=nodenames,
                 showcoord=showcoord,
                 _my_node_name=child_name,
                 indent=indent,
-                islast=(lastChild == child))
+                islast=(idx == len(self.children())-1))
 
 
 class NodeVisitor(object):


### PR DESCRIPTION
Rather than just indents, use an actual tree structure for better displaying syntax trees.

Before
![image](https://github.com/eliben/pycparser/assets/58479577/c1e5fa73-35aa-4b89-b2ae-7a36f4872061)




After:
![image](https://github.com/eliben/pycparser/assets/58479577/2b19f967-99b4-494a-8042-bf21061f4741)
