### PR TITLE
ply: Make generated lextab.py deterministic

### DIFF
--- a/pycparser/ply/lex.py
+++ b/pycparser/ply/lex.py
@@ -179,7 +179,7 @@ class Lexer:
         with open(filename, 'w') as tf:
             tf.write('# %s.py. This file automatically created by PLY (version %s). Don\'t edit!\n' % (basetabmodule, __version__))
             tf.write('_tabversion   = %s\n' % repr(__tabversion__))
-            tf.write('_lextokens    = set(%s)\n' % repr(tuple(self.lextokens)))
+            tf.write('_lextokens    = set(%s)\n' % repr(tuple(sorted(self.lextokens))))
             tf.write('_lexreflags   = %s\n' % repr(self.lexreflags))
             tf.write('_lexliterals  = %s\n' % repr(self.lexliterals))
             tf.write('_lexstateinfo = %s\n' % repr(self.lexstateinfo))


### PR DESCRIPTION
Set ordering is non-deterministic, and thus, this serializes the generated _lextokens in random order.  Adding a sorted(...) here fixes that.

Keeping the generated code deterministic comes with benefits: for hermetic build systems like Bazel which check the hashes of inputs/outputs, we can know when we don't need to rebuild code that depends on pycparser, and get better cache hits.

Note that _lextokens does not exist in upstream ply, so I patched it here directly.  If/when pycparser uprevs to a newer ply, this won't matter anymore.