### PR TITLE
ply: remove unused base64 import

### DIFF
--- a/pycparser/ply/yacc.py
+++ b/pycparser/ply/yacc.py
@@ -64,7 +64,6 @@ import types
 import sys
 import os.path
 import inspect
-import base64
 import warnings
 
 __version__    = '3.10'


### PR DESCRIPTION
Spotted this when trying to minimize runtime dependencies from the standard library in a separate project. :)