### PR TITLE
Allow abstract declarator "static" (GH issue #539)

### DIFF
--- a/pycparser/c_parser.py
+++ b/pycparser/c_parser.py
@@ -1530,6 +1530,20 @@ class CParser(PLYParser):
             type=c_ast.TypeDecl(None, None, None, None),
             coord=self._token_coord(p, 1))
 
+    def p_direct_abstract_declarator_8(self, p):
+        """ direct_abstract_declarator  : LBRACKET STATIC type_qualifier_list_opt assignment_expression RBRACKET
+                                         | LBRACKET type_qualifier_list STATIC assignment_expression RBRACKET
+        """
+        listed_quals = [item if isinstance(item, list) else [item]
+            for item in [p[2],p[3]]]
+        quals = [qual for sublist in listed_quals for qual in sublist
+            if qual is not None]
+        p[0] = c_ast.ArrayDecl(
+            type=c_ast.TypeDecl(None, None, None, None),
+            dim=p[4],
+            dim_quals=quals,
+            coord=self._token_coord(p, 1))
+
     # declaration is a list, statement isn't. To make it consistent, block_item
     # will always be a list
     #

--- a/tests/test_c_parser.py
+++ b/tests/test_c_parser.py
@@ -483,6 +483,21 @@ class TestCParser_fundamentals(TestCParser_base):
                     [['Decl', 'p', ['ArrayDecl', '10', ['static'],
                                        ['TypeDecl', ['IdentifierType', ['int']]]]]],
                     ['TypeDecl', ['IdentifierType', ['int']]]]])
+        # anonymous function parameter
+        self.assertEqual(self.get_decl('int zz(int [static 10]);'),
+            ['Decl', 'zz',
+                ['FuncDecl',
+                    [['Typename',
+                      ['ArrayDecl', '10', ['static'],
+                       ['TypeDecl', ['IdentifierType', ['int']]]]]],
+                    ['TypeDecl', ['IdentifierType', ['int']]]]])
+        self.assertEqual(self.get_decl('int zz(int [static const restrict 10]);'),
+            ['Decl', 'zz',
+                ['FuncDecl',
+                    [['Typename',
+                      ['ArrayDecl', '10', ['static', 'const', 'restrict'],
+                       ['TypeDecl', ['IdentifierType', ['int']]]]]],
+                    ['TypeDecl', ['IdentifierType', ['int']]]]])
 
         self.assertEqual(self.get_decl('int zz(int p[const 10]);'),
             ['Decl', 'zz',


### PR DESCRIPTION
This is similar to:

>    allow "static" in array parameters (GH issue #21)
>    aac7b27d7378cf45424b1f5f1b2b450c62636dde

which was revised shortly after in:

>    Fuller support for qualifiers in array dimensions.
>    8aad3186f39127ec9544f2b8c412de2bb7300fd4

The grammar is as defined in C99 6.7.6 Type names, or A.2.2 Declarations (6.7.6).