### PR TITLE
Support for labels with no statement

### DIFF
--- a/pycparser/c_parser.py
+++ b/pycparser/c_parser.py
@@ -1581,6 +1581,10 @@ class CParser(PLYParser):
         p[0] = c_ast.Default([p[3]], self._token_coord(p, 1))
 
     def p_labeled_statement_4(self, p):
+        """ labeled_statement : ID COLON SEMI"""
+        p[0] = c_ast.Label(p[1], c_ast.EmptyStatement(self._token_coord(p, 1)), self._token_coord(p, 1))
+
+    def p_labeled_statement_5(self, p):
         """ labeled_statement : ID COLON """
         p[0] = c_ast.Label(p[1], c_ast.EmptyStatement(self._token_coord(p, 1)), self._token_coord(p, 1))
 

--- a/pycparser/c_parser.py
+++ b/pycparser/c_parser.py
@@ -1580,6 +1580,10 @@ class CParser(PLYParser):
         """ labeled_statement : DEFAULT COLON pragmacomp_or_statement """
         p[0] = c_ast.Default([p[3]], self._token_coord(p, 1))
 
+    def p_labeled_statement_4(self, p):
+        """ labeled_statement : ID COLON """
+        p[0] = c_ast.Label(p[1], c_ast.EmptyStatement(self._token_coord(p, 1)), self._token_coord(p, 1))
+
     def p_selection_statement_1(self, p):
         """ selection_statement : IF LPAREN expression RPAREN pragmacomp_or_statement """
         p[0] = c_ast.If(p[3], p[5], None, self._token_coord(p, 1))

--- a/tests/test_c_parser.py
+++ b/tests/test_c_parser.py
@@ -2489,6 +2489,29 @@ class TestCParser_typenames(TestCParser_base):
             '''
         self.assertRaises(ParseError, self.parse, s2)
 
+class TestCParser_labels(TestCParser_base):
+    """ Test issues related to the labels.
+    """
+    def test_label_empty_statement(self):
+        # Parse the statements
+        s1 = r'''
+            int main() {
+                label:
+            }
+            '''
+        s2 = r'''
+            int main() {
+                label:;
+            }
+            '''
+        ast1 = self.parse(s1)
+        ast2 = self.parse(s2)
+
+        buf1 = io.StringIO()
+        buf2 = io.StringIO()
+        ast1.show(buf=buf1)
+        ast2.show(buf=buf2)
+        self.assertEqual(buf1.getvalue(), buf2.getvalue())
 
 if __name__ == '__main__':
     #~ suite = unittest.TestLoader().loadTestsFromNames(


### PR DESCRIPTION
This pull request is aimed at fixing the issue described here: https://github.com/eliben/pycparser/issues/528

The testing I did seems fine, and I implemented it through two rules to ensure that the representation of `label:` and `label:;` is the same.