### PR TITLE
fix: preserve parentheses for statement exprs

### DIFF
--- a/pycparser/c_generator.py
+++ b/pycparser/c_generator.py
@@ -133,7 +133,7 @@ class CGenerator(object):
     def _visit_expr(self, n):
         if isinstance(n, c_ast.InitList):
             return '{' + self.visit(n) + '}'
-        elif isinstance(n, c_ast.ExprList):
+        elif isinstance(n, (c_ast.ExprList, c_ast.Compound)):
             return '(' + self.visit(n) + ')'
         else:
             return self.visit(n)

--- a/tests/test_c_generator.py
+++ b/tests/test_c_generator.py
@@ -306,6 +306,13 @@ class TestCtoC(unittest.TestCase):
             }
         ''')
 
+    def test_exprlist_with_compound(self):
+        self._assert_ctoc_correct(r'''
+            void test(){
+                (sizeof (0), ({ if (0) ; else ; }));
+            }
+        ''')
+
     def test_exprlist_with_subexprlist(self):
         self._assert_ctoc_correct(r'''
             void x() {


### PR DESCRIPTION
Preserve parentheses around statement expressions when generating C code from AST. Addresses #560 