### PR TITLE
Explicit error for comments, with README link

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -110,9 +110,9 @@ Interaction with the C preprocessor
 -----------------------------------
 
 In order to be compilable, C code must be preprocessed by the C preprocessor -
-``cpp``. ``cpp`` handles preprocessing directives like ``#include`` and
+``cpp``. A compatible ``cpp`` handles preprocessing directives like ``#include`` and
 ``#define``, removes comments, and performs other minor tasks that prepare the C
-code for compilation.
+code for compilation. Note that clang's cpp does not remove comments.
 
 For all but the most trivial snippets of C code **pycparser**, like a C
 compiler, must receive preprocessed C code in order to function correctly. If

--- a/README.rst
+++ b/README.rst
@@ -112,7 +112,7 @@ Interaction with the C preprocessor
 In order to be compilable, C code must be preprocessed by the C preprocessor -
 ``cpp``. A compatible ``cpp`` handles preprocessing directives like ``#include`` and
 ``#define``, removes comments, and performs other minor tasks that prepare the C
-code for compilation. Note that clang's cpp does not remove comments.
+code for compilation.
 
 For all but the most trivial snippets of C code **pycparser**, like a C
 compiler, must receive preprocessed C code in order to function correctly. If

--- a/pycparser/c_lexer.py
+++ b/pycparser/c_lexer.py
@@ -209,6 +209,10 @@ class CLexer(object):
 
     bad_octal_constant = '0[0-7]*[89]'
 
+    # comments are not supported
+    unsupported_c89_comment = r'\/\/'
+    unsupported_c99_comment = r'\/\*'
+
     # character constants (K&R2: A.2.5.2)
     # Note: a-zA-Z and '.-~^_!=&;,' are allowed as escape chars to support #line
     # directives with Windows paths as filenames (..\..\dir\file)
@@ -473,6 +477,16 @@ class CLexer(object):
     @TOKEN(bad_octal_constant)
     def t_BAD_CONST_OCT(self, t):
         msg = "Invalid octal constant"
+        self._error(msg, t)
+
+    @TOKEN(unsupported_c89_comment)
+    def t_UNSUPPORTED_C89_COMMENT(self, t):
+        msg = "Comments are not supported (note: GCC's cpp removes comments, Clang's cpp does not)."
+        self._error(msg, t)
+
+    @TOKEN(unsupported_c99_comment)
+    def t_UNSUPPORTED_C99_COMMENT(self, t):
+        msg = "Comments are not supported (note: GCC's cpp removes comments, Clang's cpp does not)."
         self._error(msg, t)
 
     @TOKEN(octal_constant)

--- a/pycparser/c_lexer.py
+++ b/pycparser/c_lexer.py
@@ -210,8 +210,8 @@ class CLexer(object):
     bad_octal_constant = '0[0-7]*[89]'
 
     # comments are not supported
-    unsupported_c89_comment = r'\/\/'
-    unsupported_c99_comment = r'\/\*'
+    unsupported_c_style_comment = r'\/\*'
+    unsupported_cxx_style_comment = r'\/\/'
 
     # character constants (K&R2: A.2.5.2)
     # Note: a-zA-Z and '.-~^_!=&;,' are allowed as escape chars to support #line
@@ -479,14 +479,14 @@ class CLexer(object):
         msg = "Invalid octal constant"
         self._error(msg, t)
 
-    @TOKEN(unsupported_c89_comment)
-    def t_UNSUPPORTED_C89_COMMENT(self, t):
-        msg = "Comments are not supported (note: GCC's cpp removes comments, Clang's cpp does not)."
+    @TOKEN(unsupported_c_style_comment)
+    def t_UNSUPPORTED_C_STYLE_COMMENT(self, t):
+        msg = "Comments are not supported, see https://github.com/eliben/pycparser#3using."
         self._error(msg, t)
 
-    @TOKEN(unsupported_c99_comment)
-    def t_UNSUPPORTED_C99_COMMENT(self, t):
-        msg = "Comments are not supported (note: GCC's cpp removes comments, Clang's cpp does not)."
+    @TOKEN(unsupported_cxx_style_comment)
+    def t_UNSUPPORTED_CXX_STYLE_COMMENT(self, t):
+        msg = "Comments are not supported, see https://github.com/eliben/pycparser#3using."
         self._error(msg, t)
 
     @TOKEN(octal_constant)

--- a/tests/README.txt
+++ b/tests/README.txt
@@ -1,1 +1,1 @@
-Run 'python -m unittest discover' from the root pycparser directory
+Run 'python3 -m unittest discover' from the root repository directory.

--- a/tests/test_c_lexer.py
+++ b/tests/test_c_lexer.py
@@ -418,11 +418,12 @@ ERR_STRING_ESCAPE   = 'String contains invalid escape'
 ERR_FILENAME_BEFORE_LINE    = 'filename before line'
 ERR_LINENUM_MISSING         = 'line number missing'
 ERR_INVALID_LINE_DIRECTIVE  = 'invalid #line directive'
+ERR_COMMENT                 = 'Comments are not supported'
 
 
 class TestCLexerErrors(unittest.TestCase):
     """ Test lexing of erroneous strings.
-        Works by passing an error functions that saves the error
+        Works by passing an error function that saves the error
         in an attribute for later perusal.
     """
     def error_func(self, msg, line, column):
@@ -496,6 +497,9 @@ class TestCLexerErrors(unittest.TestCase):
         self.assertLexerError('#line "ka"', ERR_FILENAME_BEFORE_LINE)
         self.assertLexerError('#line df', ERR_INVALID_LINE_DIRECTIVE)
         self.assertLexerError('#line \n', ERR_LINENUM_MISSING)
+        # a compatible preprocessor must remove comments.
+        self.assertLexerError('//', ERR_COMMENT)
+        self.assertLexerError('/*', ERR_COMMENT)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
@eliben thanks so much for your blog and for pycparser!

This PR adds an explicit exception for comments, with a hint to the user that clang's cpp does not remove comments, and that simply using gcc's cpp instead will likely solve their problem.

```
$ cat foo.c
int foo() {
    // this is a comment.
    return 42;
}
```

```
$ python3 examples/c_json.py foo.c
Traceback (most recent call last):
pycparser.plyparser.ParseError: foo.c:2:5: Comments are not supported (note: GCC's cpp removes comments, Clang's cpp does not).
```

See also my [comment](https://github.com/eliben/pycparser/issues/464#issuecomment-2768804361) on a related github issue.

Hopefully this will curb the endless flood of "comments don't work" github issues! 😭