### PR TITLE
showemptyattrs option on Node.show()

### DIFF
--- a/pycparser/c_ast.py
+++ b/pycparser/c_ast.py
@@ -55,7 +55,7 @@ class Node(object):
         """
         pass
 
-    def show(self, buf=sys.stdout, offset=0, attrnames=False, hideemptyattrs=False, nodenames=False, showcoord=False, _my_node_name=None):
+    def show(self, buf=sys.stdout, offset=0, attrnames=False, showemptyattrs=True, nodenames=False, showcoord=False, _my_node_name=None):
         """ Pretty print the Node and all its attributes and
             children (recursively) to a buffer.
 
@@ -69,8 +69,8 @@ class Node(object):
                 True if you want to see the attribute names in
                 name=value pairs. False to only see the values.
 
-            hideemptyattrs:
-                True if you want to suppress printing empty attributes.
+            showemptyattrs:
+                False if you want to suppress printing empty attributes.
 
             nodenames:
                 True if you want to see the actual node names
@@ -87,11 +87,9 @@ class Node(object):
             buf.write(lead + self.__class__.__name__+ ': ')
 
         if self.attr_names:
-            nvlist = []
-            for n, v in [(n, getattr(self,n)) for n in self.attr_names]:
-                if hideemptyattrs and (v is None or (hasattr(v, '__len__') and len(v) == 0)):
-                    continue
-                nvlist.append((n,v))
+            is_empty = lambda v: v is None or (hasattr(v, '__len__') and len(v) == 0)
+            nvlist = [(n, getattr(self,n)) for n in self.attr_names \
+                        if showemptyattrs or not is_empty(getattr(self,n))]
             if attrnames:
                 attrstr = ', '.join('%s=%s' % nv for nv in nvlist)
             else:
@@ -107,7 +105,7 @@ class Node(object):
                 buf,
                 offset=offset + 2,
                 attrnames=attrnames,
-                hideemptyattrs=hideemptyattrs,
+                showemptyattrs=showemptyattrs,
                 nodenames=nodenames,
                 showcoord=showcoord,
                 _my_node_name=child_name)

--- a/pycparser/c_ast.py
+++ b/pycparser/c_ast.py
@@ -55,7 +55,7 @@ class Node(object):
         """
         pass
 
-    def show(self, buf=sys.stdout, offset=0, attrnames=False, nodenames=False, showcoord=False, _my_node_name=None):
+    def show(self, buf=sys.stdout, offset=0, attrnames=False, hideemptyattrs=False, nodenames=False, showcoord=False, _my_node_name=None):
         """ Pretty print the Node and all its attributes and
             children (recursively) to a buffer.
 
@@ -68,6 +68,9 @@ class Node(object):
             attrnames:
                 True if you want to see the attribute names in
                 name=value pairs. False to only see the values.
+
+            hideemptyattrs:
+                True if you want to suppress printing empty attributes.
 
             nodenames:
                 True if you want to see the actual node names
@@ -84,11 +87,15 @@ class Node(object):
             buf.write(lead + self.__class__.__name__+ ': ')
 
         if self.attr_names:
+            nvlist = []
+            for n, v in [(n, getattr(self,n)) for n in self.attr_names]:
+                if hideemptyattrs and (v is None or (hasattr(v, '__len__') and len(v) == 0)):
+                    continue
+                nvlist.append((n,v))
             if attrnames:
-                nvlist = [(n, getattr(self,n)) for n in self.attr_names]
                 attrstr = ', '.join('%s=%s' % nv for nv in nvlist)
             else:
-                vlist = [getattr(self, n) for n in self.attr_names]
+                vlist = [v for (n,v) in nvlist]
                 attrstr = ', '.join('%s' % v for v in vlist)
             buf.write(attrstr)
 
@@ -101,6 +108,7 @@ class Node(object):
                 buf,
                 offset=offset + 2,
                 attrnames=attrnames,
+                hideemptyattrs=hideemptyattrs,
                 nodenames=nodenames,
                 showcoord=showcoord,
                 _my_node_name=child_name)

--- a/pycparser/c_ast.py
+++ b/pycparser/c_ast.py
@@ -95,8 +95,7 @@ class Node(object):
             if attrnames:
                 attrstr = ', '.join('%s=%s' % nv for nv in nvlist)
             else:
-                vlist = [v for (n,v) in nvlist]
-                attrstr = ', '.join('%s' % v for v in vlist)
+                attrstr = ', '.join('%s' % v for (_,v) in nvlist)
             buf.write(attrstr)
 
         if showcoord:


### PR DESCRIPTION
This PR adds a `hideemptyattrs` option to `Node.show()`.  Let me know what you think!

Given `hello.c`:

```c
int main(int argc, char** argv) {
    printf("Hello, world!\n");
    return 0;
}
```

Here's a comparison of all of the options.

default `show()`:

```
ast.show(attrnames=False, hideemptyattrs=False, nodenames=False, showcoord=False):
FileAST: 
  FuncDef: 
    Decl: main, [], [], [], []
      FuncDecl: 
        ParamList: 
          Decl: argc, [], [], [], []
            TypeDecl: argc, [], None
              IdentifierType: ['int']
          Decl: argv, [], [], [], []
            PtrDecl: []
              PtrDecl: []
                TypeDecl: argv, [], None
                  IdentifierType: ['char']
        TypeDecl: main, [], None
          IdentifierType: ['int']
    Compound: 
      FuncCall: 
        ID: printf
        ExprList: 
          Constant: string, "Hello, world!\n"
      Return: 
        Constant: int, 0
```

with `hideemptyattrs`:

```
ast.show(attrnames=False, hideemptyattrs=True, nodenames=False, showcoord=False):
FileAST: 
  FuncDef: 
    Decl: main
      FuncDecl: 
        ParamList: 
          Decl: argc
            TypeDecl: argc
              IdentifierType: ['int']
          Decl: argv
            PtrDecl: 
              PtrDecl: 
                TypeDecl: argv
                  IdentifierType: ['char']
        TypeDecl: main
          IdentifierType: ['int']
    Compound: 
      FuncCall: 
        ID: printf
        ExprList: 
          Constant: string, "Hello, world!\n"
      Return: 
        Constant: int, 0
```

`attrnames=True`:

```
ast.show(attrnames=True, hideemptyattrs=False, nodenames=False, showcoord=False):
FileAST: 
  FuncDef: 
    Decl: name=main, quals=[], align=[], storage=[], funcspec=[]
      FuncDecl: 
        ParamList: 
          Decl: name=argc, quals=[], align=[], storage=[], funcspec=[]
            TypeDecl: declname=argc, quals=[], align=None
              IdentifierType: names=['int']
          Decl: name=argv, quals=[], align=[], storage=[], funcspec=[]
            PtrDecl: quals=[]
              PtrDecl: quals=[]
                TypeDecl: declname=argv, quals=[], align=None
                  IdentifierType: names=['char']
        TypeDecl: declname=main, quals=[], align=None
          IdentifierType: names=['int']
    Compound: 
      FuncCall: 
        ID: name=printf
        ExprList: 
          Constant: type=string, value="Hello, world!\n"
      Return: 
        Constant: type=int, value=0
```

with `hideemptyattrs`:

```
ast.show(attrnames=True, hideemptyattrs=True, nodenames=False, showcoord=False):
FileAST: 
  FuncDef: 
    Decl: name=main
      FuncDecl: 
        ParamList: 
          Decl: name=argc
            TypeDecl: declname=argc
              IdentifierType: names=['int']
          Decl: name=argv
            PtrDecl: 
              PtrDecl: 
                TypeDecl: declname=argv
                  IdentifierType: names=['char']
        TypeDecl: declname=main
          IdentifierType: names=['int']
    Compound: 
      FuncCall: 
        ID: name=printf
        ExprList: 
          Constant: type=string, value="Hello, world!\n"
      Return: 
        Constant: type=int, value=0
```

`nodenames=True`:

```
ast.show(attrnames=True, hideemptyattrs=False, nodenames=True, showcoord=False):
FileAST: 
  FuncDef <ext[0]>: 
    Decl <decl>: name=main, quals=[], align=[], storage=[], funcspec=[]
      FuncDecl <type>: 
        ParamList <args>: 
          Decl <params[0]>: name=argc, quals=[], align=[], storage=[], funcspec=[]
            TypeDecl <type>: declname=argc, quals=[], align=None
              IdentifierType <type>: names=['int']
          Decl <params[1]>: name=argv, quals=[], align=[], storage=[], funcspec=[]
            PtrDecl <type>: quals=[]
              PtrDecl <type>: quals=[]
                TypeDecl <type>: declname=argv, quals=[], align=None
                  IdentifierType <type>: names=['char']
        TypeDecl <type>: declname=main, quals=[], align=None
          IdentifierType <type>: names=['int']
    Compound <body>: 
      FuncCall <block_items[0]>: 
        ID <name>: name=printf
        ExprList <args>: 
          Constant <exprs[0]>: type=string, value="Hello, world!\n"
      Return <block_items[1]>: 
        Constant <expr>: type=int, value=0
```

with `hideemptyattrs`:

```
ast.show(attrnames=True, hideemptyattrs=True, nodenames=True, showcoord=False):
FileAST: 
  FuncDef <ext[0]>: 
    Decl <decl>: name=main
      FuncDecl <type>: 
        ParamList <args>: 
          Decl <params[0]>: name=argc
            TypeDecl <type>: declname=argc
              IdentifierType <type>: names=['int']
          Decl <params[1]>: name=argv
            PtrDecl <type>: 
              PtrDecl <type>: 
                TypeDecl <type>: declname=argv
                  IdentifierType <type>: names=['char']
        TypeDecl <type>: declname=main
          IdentifierType <type>: names=['int']
    Compound <body>: 
      FuncCall <block_items[0]>: 
        ID <name>: name=printf
        ExprList <args>: 
          Constant <exprs[0]>: type=string, value="Hello, world!\n"
      Return <block_items[1]>: 
        Constant <expr>: type=int, value=0
```

`showcoord=True`:

```
ast.show(attrnames=True, hideemptyattrs=False, nodenames=True, showcoord=True):
FileAST:  (at None)
  FuncDef <ext[0]>:  (at :1:5)
    Decl <decl>: name=main, quals=[], align=[], storage=[], funcspec=[] (at :1:5)
      FuncDecl <type>:  (at :1:5)
        ParamList <args>:  (at :1:14)
          Decl <params[0]>: name=argc, quals=[], align=[], storage=[], funcspec=[] (at :1:14)
            TypeDecl <type>: declname=argc, quals=[], align=None (at :1:14)
              IdentifierType <type>: names=['int'] (at :1:10)
          Decl <params[1]>: name=argv, quals=[], align=[], storage=[], funcspec=[] (at :1:25)
            PtrDecl <type>: quals=[] (at :1:25)
              PtrDecl <type>: quals=[] (at :1:24)
                TypeDecl <type>: declname=argv, quals=[], align=None (at :1:27)
                  IdentifierType <type>: names=['char'] (at :1:20)
        TypeDecl <type>: declname=main, quals=[], align=None (at :1:5)
          IdentifierType <type>: names=['int'] (at :1:1)
    Compound <body>:  (at :1:1)
      FuncCall <block_items[0]>:  (at :2:5)
        ID <name>: name=printf (at :2:5)
        ExprList <args>:  (at :2:12)
          Constant <exprs[0]>: type=string, value="Hello, world!\n" (at :2:12)
      Return <block_items[1]>:  (at :3:5)
        Constant <expr>: type=int, value=0 (at :3:12)
```

with `hideemptyattrs`:

```
ast.show(attrnames=True, hideemptyattrs=True, nodenames=True, showcoord=True):
FileAST:  (at None)
  FuncDef <ext[0]>:  (at :1:5)
    Decl <decl>: name=main (at :1:5)
      FuncDecl <type>:  (at :1:5)
        ParamList <args>:  (at :1:14)
          Decl <params[0]>: name=argc (at :1:14)
            TypeDecl <type>: declname=argc (at :1:14)
              IdentifierType <type>: names=['int'] (at :1:10)
          Decl <params[1]>: name=argv (at :1:25)
            PtrDecl <type>:  (at :1:25)
              PtrDecl <type>:  (at :1:24)
                TypeDecl <type>: declname=argv (at :1:27)
                  IdentifierType <type>: names=['char'] (at :1:20)
        TypeDecl <type>: declname=main (at :1:5)
          IdentifierType <type>: names=['int'] (at :1:1)
    Compound <body>:  (at :1:1)
      FuncCall <block_items[0]>:  (at :2:5)
        ID <name>: name=printf (at :2:5)
        ExprList <args>:  (at :2:12)
          Constant <exprs[0]>: type=string, value="Hello, world!\n" (at :2:12)
      Return <block_items[1]>:  (at :3:5)
        Constant <expr>: type=int, value=0 (at :3:12)
```
