### PR TITLE
fix bug with qualifiers on pointers

### DIFF
--- a/pycparser/c_parser.py
+++ b/pycparser/c_parser.py
@@ -307,6 +307,7 @@ class CParser(PLYParser):
 
         decl.name = type.declname
         type.quals = decl.quals[:]
+        decl.quals = list()
 
         # The typename is a list of types. If any type in this
         # list isn't an IdentifierType, it must be the only


### PR DESCRIPTION
Fixed a bug where a qualifier on the type being pointed to by a pointer would also be interpreted as a qualifier on that pointer.

Example:

```python
from pycparser import CParser
CParser().parse("const int * x;")
```