### PR TITLE
Add fake typedefs for GNU Extension 128-bit integers.

### DIFF
--- a/utils/fake_libc_include/_fake_typedefs.h
+++ b/utils/fake_libc_include/_fake_typedefs.h
@@ -153,6 +153,12 @@ typedef int uintmax_t;
 /* C99 stdbool.h bool type. _Bool is built-in in C99 */
 typedef _Bool bool;
 
+/* GNU Extension for 64-bit targets */
+#ifdef __SIZEOF_INT128__
+typedef int __int128_t;
+typedef int __uint128_t;
+#endif /* __SIZEOF_INT128__ */
+
 /* Mir typedefs */
 typedef void* MirEGLNativeWindowType;
 typedef void* MirEGLNativeDisplayType;


### PR DESCRIPTION
Applies for GNU Extensions available on 64-bit targets.
Allows pycparser to scan: `int128_t`, `uint128_t`

I created this patch after discovering pycparser 2.22 was unable to parse files with the aforementioned types.