### PR TITLE
fix: Parser fails with C23 label syntax

### DIFF
--- a/tests/test_c_parser.py
+++ b/tests/test_c_parser.py
@@ -2139,6 +2139,25 @@ class TestCParser_whole_code(TestCParser_base):
 
         self.assertEqual(switch.stmt.block_items, [])
 
+        s4 = r'''
+        int foo(void) {
+            int x = 0;
+            switch (x) {
+            default:
+            }
+            return 0;
+        }
+        '''
+        ps4 = self.parse(s4)
+        switch4 = ps4.ext[0].body.block_items[1]
+
+        block4 = switch4.stmt.block_items
+        self.assertEqual(len(block4), 1)
+        assert_default_node(block4[0])
+        # An empty default label should still contain a single EmptyStatement
+        self.assertEqual(len(block4[0].stmts), 1)
+        self.assertIsInstance(block4[0].stmts[0], EmptyStatement)
+
     def test_for_statement(self):
         s2 = r'''
         void x(void)


### PR DESCRIPTION
## Summary

Fixes an issue where pycparser was reported to fail on C23-style empty labels such as a bare `default:` inside a `switch`.  
The grammar already supports empty labels; this change adds a focused regression test to ensure that an empty `default:` is parsed correctly and remains supported.

Closes #576 

## Details

- Extend TestCParser_whole_code.test_switch_statement in tests/test_c_parser.py with a new case:

  ```c
  int foo(void) {
      int x = 0;
      switch (x) {
      default:
      }
      return 0;
  }

Contribution by Gittensor, learn more at https://gittensor.io/