### PR TITLE
Add compatibility with ply post-3.11 version

### DIFF
--- a/pycparser/_build_tables.py
+++ b/pycparser/_build_tables.py
@@ -35,6 +35,10 @@ c_parser.CParser(
 #
 importlib.invalidate_caches()
 
-import lextab
-import yacctab
+try:
+    import lextab
+    import yacctab
+except ImportError:
+    # ply post-3.11 doesn't generate table modules
+    pass
 import c_ast

--- a/pycparser/c_lexer.py
+++ b/pycparser/c_lexer.py
@@ -62,6 +62,12 @@ class CLexer(object):
             manual warns against calling lex.lex inside
             __init__
         """
+        # ply removed optimize/lextab/nowarn/outputdir after 3.11
+        if 'lextab' not in lex.lex.__code__.co_varnames:
+            kwargs.pop('optimize', None)
+            kwargs.pop('lextab', None)
+            kwargs.pop('nowarn', None)
+            kwargs.pop('outputdir', None)
         self.lexer = lex.lex(object=self, **kwargs)
 
     def reset_lineno(self):

--- a/pycparser/c_parser.py
+++ b/pycparser/c_parser.py
@@ -106,13 +106,21 @@ class CParser(PLYParser):
         for rule in rules_with_opt:
             self._create_opt_rule(rule)
 
-        self.cparser = yacc.yacc(
-            module=self,
-            start='translation_unit_or_empty',
-            debug=yacc_debug,
-            optimize=yacc_optimize,
-            tabmodule=yacctab,
-            outputdir=taboutputdir)
+        # ply removed tabmodule/outputdir after 3.11
+        if 'tabmodule' in yacc.yacc.__code__.co_varnames:
+            self.cparser = yacc.yacc(
+                module=self,
+                start='translation_unit_or_empty',
+                debug=yacc_debug,
+                optimize=yacc_optimize,
+                tabmodule=yacctab,
+                outputdir=taboutputdir)
+        else:
+            self.cparser = yacc.yacc(
+                module=self,
+                start='translation_unit_or_empty',
+                debug=yacc_debug,
+                optimize=yacc_optimize)
 
         # Stack of scopes for keeping track of symbols. _scope_stack[-1] is
         # the current (topmost) scope. Each scope is a dictionary that


### PR DESCRIPTION
ply removed table caching parameters (optimize, lextab, tabmodule, outputdir, nowarn) in its post-3.11 refactoring. Detect supported parameters at runtime and omit unsupported ones.

This change fixes the compatibility issues for distros that might unbundle ply and have it updated past its last 3.11 release.

Fixes: #588 