### PR TITLE
Fix #472: _Alignas does not work with custom types in structs

### DIFF
--- a/pycparser/c_parser.py
+++ b/pycparser/c_parser.py
@@ -961,7 +961,12 @@ class CParser(PLYParser):
     def p_specifier_qualifier_list_6(self, p):
         """ specifier_qualifier_list  : specifier_qualifier_list alignment_specifier
         """
-        p[0] = self._add_declaration_specifier(p[1], p[2], 'alignment')
+        p[0] = self._add_declaration_specifier(p[1], p[2], 'alignment', append=True)
+
+    def p_specifier_qualifier_list_7(self, p):
+        """ specifier_qualifier_list    : specifier_qualifier_list TYPEID
+        """
+        p[0] = self._add_declaration_specifier(p[1], p[2], 'type', append=True)
 
     # TYPEID is allowed here (and in other struct/enum related tag names), because
     # struct/enum tags reside in their own namespace and can be named the same as types

--- a/tests/test_c_parser.py
+++ b/tests/test_c_parser.py
@@ -2554,6 +2554,18 @@ class TestCParser_typenames(TestCParser_base):
         self.assertIsInstance(s1_ast.ext[0].body.block_items[1].stmt.block_items[1].stmts[0], EmptyStatement)
         self.assertIsInstance(s2_ast.ext[0].body.block_items[1].stmt.block_items[1].stmts[0], EmptyStatement)
 
+    def test_alignas_with_typedef_in_struct(self):
+        s = """
+            typedef int test_int;
+            typedef struct {
+                _Alignas(int) test_int a1;
+            } test_struct;
+        """
+        ast = self.parse(s) 
+        field = ast.ext[1].type.type.decls[0]
+        self.assertEqual(field.name, 'a1')
+        self.assertTrue(hasattr(field, 'align') and field.align is not None)
+
 if __name__ == '__main__':
     #~ suite = unittest.TestLoader().loadTestsFromNames(
         #~ ['test_c_parser.TestCParser_fundamentals.test_typedef'])


### PR DESCRIPTION
Hi @eliben,

This PR fixes issue #472 where the parser fails when _Alignas is followed by a custom type (typedef) inside a struct.

Key changes:

Updated p_specifier_qualifier_list_6 to use append=True to prevent losing alignment specs.

Added p_specifier_qualifier_list_7 to correctly handle TYPEID (custom types) following an alignment specifier.

All existing tests and the new test case passed successfully.