### PR TITLE
Add support for C11 _Generic selection (#559)

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -8,6 +8,8 @@ the `master` branch.
 
 ## Reporting a Vulnerability
 
-To report a security issue, please disclose it at [security advisory](https://github.com/eliben/pycparser/security/advisories/new).
+We don't consider pycparser to be a project suitable to be used at a security
+boundary. Please don't use it as such.
 
-We will respond within 14 working days of your submission. If the issue is confirmed as a vulnerability, we will open a Security Advisory and acknowledge your contributions as part of it. This project follows a 90 day disclosure timeline.
+If you found what you believe to be a security issue with pycparser, feel free
+to open a public GitHub issue or email the project's maintainer.

--- a/pycparser/_c_ast.cfg
+++ b/pycparser/_c_ast.cfg
@@ -107,6 +107,9 @@ FileAST: [ext**]
 #
 For: [init*, cond*, next*, stmt*]
 
+GenericSelection: [expr*, assoc_list**]
+GenericAssociation: [type*, expr*]
+
 # name: Id
 # args: ExprList
 #

--- a/pycparser/c_ast.py
+++ b/pycparser/c_ast.py
@@ -1128,3 +1128,33 @@ class Pragma(Node):
 
     attr_names = ('string', )
 
+class GenericAssociation(Node):
+    __slots__ = ('type', 'expr', 'coord', '__weakref__')
+    def __init__(self, type, expr, coord=None):
+        self.type = type
+        self.expr = expr
+        self.coord = coord
+
+    def children(self):
+        nodelist = []
+        if self.type is not None: nodelist.append(("type", self.type))
+        if self.expr is not None: nodelist.append(("expr", self.expr))
+        return tuple(nodelist)
+
+    attr_names = ()
+
+class GenericSelection(Node):
+    __slots__ = ('expr', 'assoc_list', 'coord', '__weakref__')
+    def __init__(self, expr, assoc_list, coord=None):
+        self.expr = expr
+        self.assoc_list = assoc_list
+        self.coord = coord
+
+    def children(self):
+        nodelist = []
+        if self.expr is not None: nodelist.append(("expr", self.expr))
+        for i, child in enumerate(self.assoc_list or []):
+            nodelist.append(("assoc_list[%d]" % i, child))
+        return tuple(nodelist)
+
+    attr_names = ()

--- a/pycparser/c_lexer.py
+++ b/pycparser/c_lexer.py
@@ -113,6 +113,7 @@ class CLexer(object):
         '_NORETURN', '_THREAD_LOCAL', '_STATIC_ASSERT',
         '_ATOMIC', '_ALIGNOF', '_ALIGNAS',
         '_PRAGMA',
+        '_GENERIC',
         )
 
     keyword_map = {}

--- a/pycparser/c_parser.py
+++ b/pycparser/c_parser.py
@@ -1835,6 +1835,30 @@ class CParser(PLYParser):
         p[0] = c_ast.FuncCall(c_ast.ID(p[1], coord),
                               c_ast.ExprList([p[3], p[5]], coord),
                               coord)
+        
+    def p_primary_expression_6(self, p):
+        """ primary_expression  : generic_selection """
+        p[0] = p[1]
+
+    def p_generic_selection(self, p):
+        """ generic_selection : _GENERIC LPAREN assignment_expression COMMA generic_assoc_list RPAREN """
+        p[0] = c_ast.GenericSelection(p[3], p[5], self._token_coord(p, 1))
+
+    def p_generic_assoc_list_1(self, p):
+        """ generic_assoc_list : generic_association """
+        p[0] = [p[1]]
+
+    def p_generic_assoc_list_2(self, p):
+        """ generic_assoc_list : generic_assoc_list COMMA generic_association """
+        p[0] = p[1] + [p[3]]
+
+    def p_generic_association_1(self, p):
+        """ generic_association : type_name COLON assignment_expression """
+        p[0] = c_ast.GenericAssociation(p[1], p[3], p[1].coord)
+
+    def p_generic_association_2(self, p):
+        """ generic_association : DEFAULT COLON assignment_expression """
+        p[0] = c_ast.GenericAssociation(None, p[3], self._token_coord(p, 1))
 
     def p_offsetof_member_designator(self, p):
         """ offsetof_member_designator : identifier


### PR DESCRIPTION
Hi @eliben,

This PR implements support for the C11 _Generic keyword, addressing issue #559.

The implementation follows the C11 standard by adding _Generic as a primary expression.

Changes:
Lexer: Added _GENERIC to the keywords list in c_lexer.py.

AST:

Updated _c_ast.cfg with GenericSelection and GenericAssociation nodes.

Regenerated c_ast.py to include the new node classes.

Parser:

Added p_primary_expression_6 to support generic_selection.

Added rules for generic_selection, generic_assoc_list, and generic_association.

Updated p_primary_expression to include the new rule.

<img width="1344" height="496" alt="Screenshot (46)" src="https://github.com/user-attachments/assets/dc4e0b03-d878-4c6f-a600-416fbb826bd5" />

Validation:
Conflicts: After adding the rules, the parser now reports 173 shift/reduce and 180 reduce/reduce conflicts (a minimal increase of 3/3, which is expected for this feature).

Manual Testing: Verified with a test script parsing complex _Generic expressions.

update: I've run the tests locally using python -m unittest discover tests and everything passed (133 tests). Ready for your review whenever the workflows are approved.