### PR TITLE
Add lexer support for complex literals.

### DIFF
--- a/pycparser/c_lexer.py
+++ b/pycparser/c_lexer.py
@@ -537,6 +537,7 @@ _u32string_literal = "U" + _string_literal
 _bad_string_literal = '"' + _string_char + "*" + _bad_escape + _string_char + '*"'
 
 # floating constants (K&R2: A.2.5.3)
+_floating_suffix_opt = r"([FfLl][iIjJ]?|[iIjJ][FfLl]?)?"
 _exponent_part = r"""([eE][-+]?[0-9]+)"""
 _fractional_constant = r"""([0-9]*\.[0-9]+)|([0-9]+\.)"""
 _floating_constant = (
@@ -546,7 +547,9 @@ _floating_constant = (
     + _exponent_part
     + "?)|([0-9]+"
     + _exponent_part
-    + "))[FfLl]?)"
+    + "))"
+    + _floating_suffix_opt
+    + ")"
 )
 _binary_exponent_part = r"""([pP][+-]?[0-9]+)"""
 _hex_fractional_constant = (
@@ -561,7 +564,8 @@ _hex_floating_constant = (
     + _hex_fractional_constant
     + ")"
     + _binary_exponent_part
-    + "[FfLl]?)"
+    + _floating_suffix_opt
+    + ")"
 )
 
 

--- a/tests/test_c_lexer.py
+++ b/tests/test_c_lexer.py
@@ -128,6 +128,21 @@ class TestCLexerNoErrors(unittest.TestCase):
         self.assertTokensTypes("0x.488641p0", ["HEX_FLOAT_CONST"])
         self.assertTokensTypes("0X12.P0", ["HEX_FLOAT_CONST"])
 
+    def test_complex_constants(self):
+        self.assertTokensTypes("1.2i", ["FLOAT_CONST"])
+        self.assertTokensTypes("1.2I", ["FLOAT_CONST"])
+        self.assertTokensTypes("1.2j", ["FLOAT_CONST"])
+        self.assertTokensTypes("1.2J", ["FLOAT_CONST"])
+        self.assertTokensTypes("1.2fi", ["FLOAT_CONST"])
+        self.assertTokensTypes("1.2if", ["FLOAT_CONST"])
+
+        self.assertTokensTypes("0x1.2p3i", ["HEX_FLOAT_CONST"])
+        self.assertTokensTypes("0x1.2p3I", ["HEX_FLOAT_CONST"])
+        self.assertTokensTypes("0x1.2p3j", ["HEX_FLOAT_CONST"])
+        self.assertTokensTypes("0x1.2p3J", ["HEX_FLOAT_CONST"])
+        self.assertTokensTypes("0x1.2p3fi", ["HEX_FLOAT_CONST"])
+        self.assertTokensTypes("0x1.2p3if", ["HEX_FLOAT_CONST"])
+
     def test_char_constants(self):
         self.assertTokensTypes(r"""'x'""", ["CHAR_CONST"])
         self.assertTokensTypes(r"""L'x'""", ["WCHAR_CONST"])


### PR DESCRIPTION
They are part of the current C2y ISO draft (included by N3298 [1]).

[1] https://www.open-std.org/jtc1/sc22/wg14/www/docs/n3298.htm