### PR TITLE
fix: handle integer suffix in #line directive without crashing

### DIFF
--- a/pycparser/c_lexer.py
+++ b/pycparser/c_lexer.py
@@ -278,7 +278,11 @@ class CLexer:
             if pp_line is None:
                 self._error("line number missing in #line", self._pos + line_len)
             else:
-                self._lineno = int(pp_line)
+                try:
+                    self._lineno = int(pp_line)
+                except ValueError:
+                    self._error("invalid #line directive", self._pos + line_len)
+                    return
                 if pp_filename is not None:
                     self._filename = pp_filename
             self._pos = line_end + 1

--- a/tests/test_c_lexer.py
+++ b/tests/test_c_lexer.py
@@ -572,6 +572,10 @@ class TestCLexerErrors(unittest.TestCase):
         self.assertLexerError('#line "ka"', ERR_FILENAME_BEFORE_LINE)
         self.assertLexerError("#line df", ERR_INVALID_LINE_DIRECTIVE)
         self.assertLexerError("#line \n", ERR_LINENUM_MISSING)
+        # Integer suffixes are not valid in #line directives (issue #587).
+        self.assertLexerError("#line 0u", ERR_INVALID_LINE_DIRECTIVE)
+        self.assertLexerError("#line 1U", ERR_INVALID_LINE_DIRECTIVE)
+        self.assertLexerError("#line 10uLL", ERR_INVALID_LINE_DIRECTIVE)
         # a compatible preprocessor must remove comments.
         self.assertLexerError("//", ERR_COMMENT)
         self.assertLexerError("/*", ERR_COMMENT)


### PR DESCRIPTION
A `#line` directive with an integer suffix (e.g. `#line 0u`) caused an unhandled `ValueError: invalid literal for int() with base 10: '0u'` in `c_lexer.py`. The `_decimal_constant` regex already accepts suffixes like `u`/`U`/`l`/`L`, so a fuzz-generated input with a suffixed line number reaches `int(pp_line)` and crashes.

This wraps the `int()` call in a `try/except ValueError` and reports a proper `"invalid #line directive"` parse error instead. Three tests added to `TestCLexerErrors.test_preprocessor` covering `0u`, `1U`, and `10uLL`.

Closes #587