### PR TITLE
fix: raise ParseError instead of AssertionError on unmatched '}'

### DIFF
--- a/pycparser/c_parser.py
+++ b/pycparser/c_parser.py
@@ -124,7 +124,8 @@ class CParser:
         self._scope_stack.append(dict())
 
     def _pop_scope(self) -> None:
-        assert len(self._scope_stack) > 1
+        if len(self._scope_stack) <= 1:
+            raise ParseError("Unmatched '}'")
         self._scope_stack.pop()
 
     def _add_typedef_name(self, name: str, coord: Optional[Coord]) -> None:

--- a/tests/test_c_parser.py
+++ b/tests/test_c_parser.py
@@ -3783,3 +3783,11 @@ if __name__ == "__main__":
 
     # ~ unittest.TextTestRunner(verbosity=2).run(suite)
     unittest.main()
+
+class TestUnmatchedRbrace(unittest.TestCase):
+    """Regression for #603: unmatched '}' raises ParseError, not AssertionError."""
+
+    def test_unmatched_rbrace_raises_parse_error(self):
+        parser = c_parser.CParser()
+        with self.assertRaises(ParseError):
+            parser.parse("}", filename="test.c")


### PR DESCRIPTION
## Problem

`parser.parse("}")` — an unmatched `}` — raises `AssertionError` from parser internals instead of the documented `ParseError`:

```
CLexer tokenizes RBRACE
  -> on_rbrace_func()
  -> CParser._lex_on_rbrace_func()
  -> CParser._pop_scope()
  -> assert len(self._scope_stack) > 1   # AssertionError
```

Callers that catch `ParseError` to handle parse failures cannot catch the `AssertionError`.

## Cause

`_pop_scope` (c_parser.py:127) uses a bare `assert` to guard against an empty scope stack. Assertions are for invariant checks, not for user-input validation — and they vanish under `python -O`.

## Fix

Replace the bare assert with an explicit `ParseError`:

```python
def _pop_scope(self) -> None:
    if len(self._scope_stack) <= 1:
        raise ParseError("Unmatched '}'")
    self._scope_stack.pop()
```

## Test

Added `TestUnmatchedRbrace::test_unmatched_rbrace_raises_parse_error` — fails on unpatched (AssertionError), passes with the fix. Full suite: 135 passed, 0 regressions (the 1 pre-existing `test_examples` failure is unrelated — `AttributeError: Coord` on master HEAD).

Fixes #603.

Assisted-by: Claude (Anthropic).
