### PR TITLE
Add support for Python 3.15

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14", "3.15"]
         os: [ubuntu-latest, macos-latest, windows-latest]
 
     steps:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,7 @@ classifiers = [
   "Programming Language :: Python :: 3.12",
   "Programming Language :: Python :: 3.13",
   "Programming Language :: Python :: 3.14",
+  "Programming Language :: Python :: 3.15",
 ]
 
 [project.urls]


### PR DESCRIPTION
Python 3.15 is now in release candidate phase, meaning it's stable enough to test on and to declare support for. This PR adds 3.15 to the classifiers and to the CI matrix. I ran tests under 3.15.0rc1 locally, and all pass :)